### PR TITLE
FIA field style updates

### DIFF
--- a/config/install/core.entity_view_mode.node.facebook_instant_articles_rss.yml
+++ b/config/install/core.entity_view_mode.node.facebook_instant_articles_rss.yml
@@ -1,8 +1,8 @@
 langcode: en
 status: false
 dependencies:
-  module:
-    - node
+    module:
+        - node
 id: node.facebook_instant_articles_rss
 label: 'Facebook Instant Articles: RSS'
 targetEntityType: node

--- a/config/install/views.view.facebook_instant_articles.yml
+++ b/config/install/views.view.facebook_instant_articles.yml
@@ -1,15 +1,12 @@
 langcode: en
 status: true
 dependencies:
-  config:
-    - core.entity_view_mode.node.rss
-    - core.entity_view_mode.node.teaser
-  module:
-    - facebook_instant_articles
-    - node
-    - user
-_core:
-  default_config_hash: 3R93S28dH6_BFeCFbMHefgyaTQYuRFJg4c-sRbxJQlc
+    config:
+        - core.entity_view_mode.node.facebook_instant_articles_rss
+    module:
+        - facebook_instant_articles
+        - node
+        - user
 id: facebook_instant_articles
 label: 'FaceBook Instant Articles'
 module: views
@@ -19,232 +16,213 @@ base_table: node_field_data
 base_field: nid
 core: 8.x
 display:
-  default:
-    display_plugin: default
-    id: default
-    display_title: Master
-    position: 0
-    display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
-          quantity: 9
-      style:
-        type: default
-      row:
-        type: 'entity:node'
-        options:
-          view_mode: teaser
-      fields:
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          entity_type: node
-          entity_field: title
-          label: ''
-          alter:
-            alter_text: false
-            make_link: false
-            absolute: false
-            trim: false
-            word_boundary: false
-            ellipsis: false
-            strip_tags: false
-            html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-      filters:
-        status:
-          value: true
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-          group: 1
-        facebook_instant_articles:
-          id: facebook_instant_articles
-          table: node_field_data
-          field: facebook_instant_articles
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          entity_type: node
-          plugin_id: validfacebookinstantarticles
-      sorts:
-        created:
-          id: created
-          table: node_field_data
-          field: created
-          order: DESC
-          entity_type: node
-          entity_field: created
-          plugin_id: date
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-      title: 'FaceBook Instant Articles'
-      header: {  }
-      footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
-      display_extenders: {  }
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url.query_args
-        - 'user.node_grants:view'
-        - user.permissions
-      tags: {  }
-  feed_fia_rss:
-    display_plugin: feed
-    id: feed_fia_rss
-    display_title: 'FIA node feed'
-    position: 2
-    display_options:
-      sitename_title: true
-      path: fia/nodes.xml
-      displays:
-        page_1: page_fia_admin
-        default: ''
-      pager:
-        type: some
-        options:
-          items_per_page: 10
-          offset: 0
-      style:
-        type: rss
-        options:
-          description: ''
-          grouping: {  }
-          uses_fields: false
-      row:
-        type: node_rss
-        options:
-          relationship: none
-          view_mode: rss
-      display_extenders: {  }
-    cache_metadata:
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - 'user.node_grants:view'
-        - user.permissions
-      max-age: -1
-      tags: {  }
-  page_fia_admin:
-    display_plugin: page
-    id: page_fia_admin
-    display_title: 'FIA admin page'
-    position: 1
-    display_options:
-      display_extenders: {  }
-      path: admin/config/content/facebook-instant-articles
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url.query_args
-        - 'user.node_grants:view'
-        - user.permissions
-      tags: {  }
+    default:
+        display_plugin: default
+        id: default
+        display_title: Master
+        position: 0
+        display_options:
+            access:
+                type: perm
+                options:
+                    perm: 'access content'
+            cache:
+                type: tag
+                options: {  }
+            query:
+                type: views_query
+                options:
+                    disable_sql_rewrite: false
+                    distinct: false
+                    replica: false
+                    query_comment: ''
+                    query_tags: {  }
+            exposed_form:
+                type: basic
+                options:
+                    submit_button: Apply
+                    reset_button: false
+                    reset_button_label: Reset
+                    exposed_sorts_label: 'Sort by'
+                    expose_sort_order: true
+                    sort_asc_label: Asc
+                    sort_desc_label: Desc
+            pager:
+                type: full
+                options:
+                    items_per_page: 100
+                    offset: 0
+                    id: 0
+                    total_pages: null
+                    expose:
+                        items_per_page: false
+                        items_per_page_label: 'Items per page'
+                        items_per_page_options: '5, 10, 25, 50'
+                        items_per_page_options_all: false
+                        items_per_page_options_all_label: '- All -'
+                        offset: false
+                        offset_label: Offset
+                    tags:
+                        previous: '‹ Previous'
+                        next: 'Next ›'
+                        first: '« First'
+                        last: 'Last »'
+                    quantity: 9
+            style:
+                type: default
+            row:
+                type: 'entity:node'
+                options:
+                    view_mode: teaser
+            fields:
+                title:
+                    id: title
+                    table: node_field_data
+                    field: title
+                    entity_type: node
+                    entity_field: title
+                    label: ''
+                    alter:
+                        alter_text: false
+                        make_link: false
+                        absolute: false
+                        trim: false
+                        word_boundary: false
+                        ellipsis: false
+                        strip_tags: false
+                        html: false
+                    hide_empty: false
+                    empty_zero: false
+                    settings:
+                        link_to_entity: true
+                    plugin_id: field
+                    relationship: none
+                    group_type: group
+                    admin_label: ''
+                    exclude: false
+                    element_type: ''
+                    element_class: ''
+                    element_label_type: ''
+                    element_label_class: ''
+                    element_label_colon: true
+                    element_wrapper_type: ''
+                    element_wrapper_class: ''
+                    element_default_classes: true
+                    empty: ''
+                    hide_alter_empty: true
+                    click_sort_column: value
+                    type: string
+                    group_column: value
+                    group_columns: {  }
+                    group_rows: true
+                    delta_limit: 0
+                    delta_offset: 0
+                    delta_reversed: false
+                    delta_first_last: false
+                    multi_type: separator
+                    separator: ', '
+                    field_api_classes: false
+            filters:
+                status:
+                    value: true
+                    table: node_field_data
+                    field: status
+                    plugin_id: boolean
+                    entity_type: node
+                    entity_field: status
+                    id: status
+                    expose:
+                        operator: ''
+                    group: 1
+                facebook_instant_articles:
+                    id: facebook_instant_articles
+                    table: node_field_data
+                    field: facebook_instant_articles
+                    relationship: none
+                    group_type: group
+                    admin_label: ''
+                    operator: '='
+                    value: ''
+                    group: 1
+                    exposed: false
+                    expose:
+                        operator_id: ''
+                        label: ''
+                        description: ''
+                        use_operator: false
+                        operator: ''
+                        identifier: ''
+                        required: false
+                        remember: false
+                        multiple: false
+                        remember_roles:
+                            authenticated: authenticated
+                    is_grouped: false
+                    entity_type: node
+                    plugin_id: validfacebookinstantarticles
+            sorts:
+                created:
+                    id: created
+                    table: node_field_data
+                    field: created
+                    order: DESC
+                    entity_type: node
+                    entity_field: created
+                    plugin_id: date
+                    relationship: none
+                    group_type: group
+                    admin_label: ''
+                    exposed: false
+                    expose:
+                        label: ''
+                    granularity: second
+            title: 'FaceBook Instant Articles'
+            header: {  }
+            footer: {  }
+            empty: {  }
+            relationships: {  }
+            arguments: {  }
+            display_extenders: {  }
+        cache_metadata:
+            max-age: -1
+            contexts:
+                - 'languages:language_content'
+                - 'languages:language_interface'
+                - url.query_args
+                - 'user.node_grants:view'
+                - user.permissions
+            tags: {  }
+    feed_fia_rss:
+        display_plugin: feed
+        id: feed_fia_rss
+        display_title: 'FIA node feed'
+        position: 2
+        display_options:
+            sitename_title: true
+            path: fia/nodes.xml
+            displays:
+                page_1: page_fia_admin
+                default: ''
+            pager:
+                type: some
+                options:
+                    items_per_page: 10
+                    offset: 0
+            style:
+                type: fia
+                options:
+                    uses_fields: false
+            row:
+                type: fiafields
+                options:
+                    relationship: none
+                    view_mode: facebook_instant_articles_rss
+            display_extenders: {  }
+        cache_metadata:
+            contexts:
+                - 'languages:language_content'
+                - 'languages:language_interface'
+                - 'user.node_grants:view'
+                - user.permissions
+            max-age: -1
+            tags: {  }

--- a/facebook_instant_articles.info.yml
+++ b/facebook_instant_articles.info.yml
@@ -1,9 +1,11 @@
-name: Facebook instant articles
+name: 'Facebook instant articles'
 type: module
-description: FB Instant articles RSS feed generator for integration into the FB IA program
+description: 'FB Instant articles RSS feed generator for integration into the FB IA program'
 core: 8.x
 package: Facebook
 features: true
 dependencies:
-  - node
-  - views
+    0: node
+    1: views
+    2: facebook_instant_articles
+    4: user

--- a/templates/views-view-row-fia.html.twig
+++ b/templates/views-view-row-fia.html.twig
@@ -4,7 +4,7 @@
  * Default theme implementation to display an item in a views FIA (facebook instant articles) feed.
  *
  * Available variables:
- * - options.header.title: RSS item title.
+ * - options.title: RSS item title.
  * - header.subtitle: RSS item subtitle.
  * - header.kicker : teaser short text for the article
  * - header.created : created datetime
@@ -43,34 +43,37 @@
 <article>
   <header>
     <!-- The title and subtitle shown in your Instant Article -->
-    <h1>{{ options.header.title }}</h1>
-    {% if options.header.subtitle -%}
-      <h2>{{ options.header.subtitle }}</h2>
+    <h1>{{ options.title }}</h1>
+    {% if options.subtitle -%}
+      <h2>{{ options.subtitle }}</h2>
     {% endif %}
 
-    <!-- The date and time when your article was originally published {{ options.header.created }} -->
-    <time class="op-published" datetime="{{ options.header.created|date("Y-d-m\TH:i:s\Z") }}">{{ options.header.created|date("F jS, g:i A") }}</time>
-    <!-- The date and time when your article was last updated {{  header.modified }} -->
-    <time class="op-modified" datetime="{{ options.header.modified|date("Y-d-m\TH:i:s\Z") }}">{{ options.header.modified|date("F jS, g:i A") }}</time>
+    <!-- The date and time when your article was originally published {{ options.created }} -->
+    <time class="op-published" datetime="{{ options.created|date("Y-d-m\TH:i:s\Z") }}">{{ options.created|date("F jS, g:i A") }}</time>
+    <!-- The date and time when your article was last updated {{  options.modified }} -->
+    <time class="op-modified" datetime="{{ options.modified|date("Y-d-m\TH:i:s\Z") }}">{{ options.modified|date("F jS, g:i A") }}</time>
 
-    <!-- A kicker for your article -->
     {% if kicker -%}
+      <!-- A kicker for your article -->
       <h3 class="op-kicker">{{ kicker }}</h3>
     {% endif %}
-
-    {% if options.header.figure -%}
+    {% if options.figure -%}
       <!-- The cover image shown inside your article -->
       {{ header.figure }}
     {% endif %}
-
-    {% if options.header.authors -%}
+    {% if options.authors -%}
+      {%  for author in options.authors %}
       <!-- The authors of your article -->
-      {{ options.header.authors }}
+        <address>{{  author }}</address>
+      {%  endfor %}
     {% endif %}
 
   </header>
 
+
+  <!-- ARTICLE CONTENT START -->
   {{ row }}
+  <!-- ARTICLE CONTENT FINISH -->
 
   {% if footer -%}
     <footer>


### PR DESCRIPTION
This patch converts the views row handler to be based on the EntityRow handler, in order to get the rendered node into the FIA article body.  Also some clean up on the template variables, and removal of the fia node page from the view.
