### PR TITLE
FIA new administration config form, for assigning FB pages id

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ There is an administration page located at /admin/config/facebook_instant_articl
 In this page you can set
 
 - pages id: A facebook provide id, that is used to insert a <meta> tag
-into all Drupal pages that will look like <meta property="fb:pages" content=""
+into all Drupal pages that will look like <meta property="fb:pages" content="{id goes here}" />

--- a/README.md
+++ b/README.md
@@ -2,3 +2,18 @@
 
 A custom module to produce an RSS field that is compatible with the
 Facebook Instant Articles program.
+
+## To use
+
+First install the module into your application using the standard approach: https://www.drupal.org/documentation/install/modules-themes/modules-8
+
+Then make sure to configure the module as described below.
+
+## to configure
+
+There is an administration page located at /admin/config/facebook_instant_articles/adminconfig
+
+In this page you can set
+
+- pages id: A facebook provide id, that is used to insert a <meta> tag
+into all Drupal pages that will look like <meta property="fb:pages" content=""

--- a/facebook_instant_articles.info.yml
+++ b/facebook_instant_articles.info.yml
@@ -7,5 +7,4 @@ features: true
 dependencies:
     0: node
     1: views
-    2: facebook_instant_articles
-    4: user
+    2: user

--- a/facebook_instant_articles.links.menu.yml
+++ b/facebook_instant_articles.links.menu.yml
@@ -1,0 +1,7 @@
+facebook_instant_articles.fia_admin_config:
+  title: 'FaceBook Instant Articles administration'
+  route_name: facebook_instant_articles.fia_admin_config
+  description: 'Configure FaceBook Instant Articles'
+  parent: system.admin_config_system
+  weight: 99
+

--- a/facebook_instant_articles.module
+++ b/facebook_instant_articles.module
@@ -39,7 +39,7 @@ function facebook_instant_articles_page_attachments_alter(array &$page) {
      * then add a page <meta> tag to all pages showing the id
      */
 
-    $fia_pagesid = git$config->get('pagesid');
+    $fia_pagesid = $config->get('pagesid');
     if ($fia_pagesid != '') {
       $meta_fia_pagesid = [
         '#tag' => 'meta',

--- a/facebook_instant_articles.module
+++ b/facebook_instant_articles.module
@@ -24,6 +24,12 @@ function facebook_instant_articles_help($route_name, RouteMatchInterface $route_
   }
 }
 
+/**
+ * Implements hook_page_attachments_alter
+ *
+ * @param array $page
+ *   page render array
+ */
 function facebook_instant_articles_page_attachments_alter(array &$page) {
 
   /**
@@ -37,6 +43,8 @@ function facebook_instant_articles_page_attachments_alter(array &$page) {
     /**
      * If there is a stored configuration for the FIA Application ID
      * then add a page <meta> tag to all pages showing the id
+     *
+     * <meta property="fb:pages" content="{id goes here}" />
      */
 
     $fia_pagesid = $config->get('pagesid');

--- a/facebook_instant_articles.module
+++ b/facebook_instant_articles.module
@@ -24,41 +24,34 @@ function facebook_instant_articles_help($route_name, RouteMatchInterface $route_
   }
 }
 
-/**
- * Prepares variables for FIA feed templates.
- *
- * Default template: views-view-fia.html.twig.
- *
- * @param array $variables
- *   An associative array containing:
- *   - view: A ViewExecutable object.
- *   - rows: The raw row data.
- */
-function facebook_instant_articles_preprocess_views_view_fia(&$variables) {
-  GLOBAL $base_url;
+function facebook_instant_articles_page_attachments_alter(array &$page) {
 
-  $view  = $variables['view'];
-  $items = $variables['rows'];
+  /**
+   * @var Drupal\Core\Config\ImmutableConfig $config
+   *   The config entity for facebook_instant_articles
+   */
+  $config = \Drupal::config('facebook_instant_articles.adminconfig');
 
-  $config = \Drupal::config('system.site');
+  if ($config instanceof Drupal\Core\Config\ImmutableConfig) {
 
-  if ($view->display_handler->getOption('sitename_title')) {
-    $title = $config->get('name');
-    if ($slogan = $config->get('slogan')) {
-      $title .= ' - ' . $slogan;
+    /**
+     * If there is a stored configuration for the FIA Application ID
+     * then add a page <meta> tag to all pages showing the id
+     */
+
+    $fia_pagesid = git$config->get('pagesid');
+    if ($fia_pagesid != '') {
+      $meta_fia_pagesid = [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'property' => 'fb:pages',
+          'content' => $fia_pagesid,
+        ],
+      ];
+      $page['#attached']['html_head'][] = [$meta_fia_pagesid, 'fia_pagesid'];
     }
+
   }
-  else {
-    $title = $view->getTitle();
-  }
-
-  $variables['items'] = $items;
-
-  $variables['options']['title'] = $title;
-  $variables['options']['link'] = $base_url;
-  $variables['options']['updated'] = gmdate(DATE_RFC2822, REQUEST_TIME);
-  $variables['options']['markup_version'] = 'v1.0';
-
 }
 
 /**

--- a/facebook_instant_articles.routing.yml
+++ b/facebook_instant_articles.routing.yml
@@ -1,0 +1,11 @@
+
+facebook_instant_articles.fia_admin_config:
+  path: '/admin/config/facebook_instant_articles/adminconfig'
+  defaults:
+    _form: '\Drupal\facebook_instant_articles\Form\AdminConfig'
+    _title: 'AdminConfig'
+  requirements:
+    _permission: 'access administration pages'
+  options:
+    _admin_route: TRUE
+

--- a/src/Form/AdminConfig.php
+++ b/src/Form/AdminConfig.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\facebook_instant_articles\Form\AdminConfig.
+ */
+
+namespace Drupal\facebook_instant_articles\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Class AdminConfig.
+ *
+ * @package Drupal\facebook_instant_articles\Form
+ */
+class AdminConfig extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'facebook_instant_articles.adminconfig',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'fia_admin_config';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('facebook_instant_articles.adminconfig');
+    $form['pagesid'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('FaceBook application ID'),
+      '#description' => $this->t('The facebook application id is used in the drupal site, to identify the site to facebook, as participating in facebook applications.  The primary impact is the addition of a metatag to the drupal application <meta property="fb:pages" content="{application id}"/>.'),
+      '#maxlength' => 64,
+      '#size' => 64,
+      '#default_value' => $config->get('pagesid'),
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $this->config('facebook_instant_articles.adminconfig')
+      ->set('pagesid', $form_state->getValue('pagesid'))
+      ->save();
+  }
+
+}


### PR DESCRIPTION
The FaceBook Instant Articles API requires that if you assign a canonical link to your articles pages, that a corresponding <meta> tag is shown on your canonical URL, that includes the FB pages ID.

There is now a new form at Drupal URL /admin/config/facebook_instant_articles/adminconfig that lets you enter a pages ID, which will create the corresponding <meta> tag.

Some documentation is available here: https://developers.facebook.com/docs/instant-articles/claim-url
But this requirement isn't clear until you try to assign a URL to your FaceBook instant articles configuration, where the <meta> tag requirements are shown.
