### PR TITLE
Issue #2694863: fix php warning by checking for node type while creating new content / node-id while editing existing content

### DIFF
--- a/fb_instant_articles.module
+++ b/fb_instant_articles.module
@@ -443,7 +443,11 @@ function fb_instant_articles_form_alter(&$form, &$form_state, $form_id) {
 
             // Is an Article?
             $type = $form['#node']->type;
-            $fb_instant_enabled = fb_instant_articles_is_article($form['#node']->nid);
+            if (!empty($form['#node']->nid)) {
+              $fb_instant_enabled = fb_instant_articles_is_article($form['#node']->nid);
+            } else {
+              $fb_instant_enabled = fb_instant_articles_is_article_type('node', $type);
+            }
 
             // Previously checked the product checkbox?
             $previously_checked = (isset($form_state['values']) && $form_state['values']['fb_instant_articles']['fb_instant_enabled']);


### PR DESCRIPTION
Related issue - https://www.drupal.org/node/2694863/edit
