### PR TITLE
Issue #2704695: Missing id column in INSERT statement for fb_instant_articles_display_entity_types table

### DIFF
--- a/modules/fb_instant_articles_display/fb_instant_articles_display.module
+++ b/modules/fb_instant_articles_display/fb_instant_articles_display.module
@@ -139,6 +139,7 @@ function fb_instant_articles_display_get_article_entity_types() {
 function fb_instant_articles_display_set_entity_type($type, $bundle) {
   db_insert('fb_instant_articles_display_entity_types')
     ->fields(array(
+      'id' => $type . '|' . $bundle,
       'entity_type' => $type,
       'entity_bundle' => $bundle,
     ))


### PR DESCRIPTION
Otherwise the features export doesn't have a key value to use in the export.
