### PR TITLE
Issue #2709297: Missing </html> tag on wrapping markup for Transformer field formatter

### DIFF
--- a/modules/fb_instant_articles_display/src/DrupalInstantArticleDisplay.php
+++ b/modules/fb_instant_articles_display/src/DrupalInstantArticleDisplay.php
@@ -472,7 +472,7 @@ class DrupalInstantArticleDisplay {
       // Before loading into DOMDocument, setup for success by taking care of
       // encoding issues.  Since we're dealing with HTML snippets, it will
       // always be missing a <meta charset="utf-8" /> or equivalent.
-      $output = '<!doctype html><html><head><meta charset="utf-8" /></head><body>' . $output . '</body>';
+      $output = '<!doctype html><html><head><meta charset="utf-8" /></head><body>' . $output . '</body></html>';
       @$document->loadHTML($output);
       $transformer->transform($body, $document);
 


### PR DESCRIPTION
Resolves https://www.drupal.org/node/2709297.
