### PR TITLE
Issue #2714683 : Getting Fatal error: Call to a member function getArticle()

### DIFF
--- a/modules/fb_instant_articles_api_rules/fb_instant_articles_api_rules.module
+++ b/modules/fb_instant_articles_api_rules/fb_instant_articles_api_rules.module
@@ -63,6 +63,9 @@ function facebook_instant_articles_api_remove_action($node, $context = array()) 
  */
 function fb_instant_articles_api_rules_import_article($node) {
   if (isset($node->nid)) {
+    // We duplicate this because hook_node_load() is not triggered during node_insert().
+    $layout_settings = fb_instant_articles_display_get_node_layout_settings($node->type);
+    $node->fb_instant_articles_display_wrapper = \Drupal\fb_instant_articles_display\DrupalInstantArticleDisplay::create($node, $layout_settings);
     node_build_content($node, $view_mode = 'fb_instant_article');
     $client = \Drupal\fb_instant_articles_api\DrupalClient::get();
     $client->importArticle($node->fb_instant_articles_display_wrapper->getArticle(), $node->status === NODE_PUBLISHED);

--- a/modules/fb_instant_articles_display/fb_instant_articles_display.module
+++ b/modules/fb_instant_articles_display/fb_instant_articles_display.module
@@ -176,21 +176,14 @@ function fb_instant_articles_display_entity_info_alter(&$entity_info) {
 }
 
 /**
- * Implements hook_node_load().
+ * Implements hook_node_view().
  */
-function fb_instant_articles_display_node_load($nodes, $types) {
-  if ($enabled_entity_types = fb_instant_articles_display_get_article_entity_types()) {
+function fb_instant_articles_display_node_view($node, $view_mode, $langcode) {
+  if ($view_mode == 'fb_instant_article' && $enabled_entity_types = fb_instant_articles_display_get_article_entity_types()) {
     $enabled_bundles = array_keys($enabled_entity_types['node']);
-
-    if (!empty($enabled_bundles) && count(array_intersect($enabled_bundles, $types))) {
-      foreach ($nodes as $node) {
-        $layout_settings = fb_instant_articles_display_get_node_layout_settings($node->type);
-        $wrapper = \Drupal\fb_instant_articles_display\DrupalInstantArticleDisplay::create($node, $layout_settings);
-        // Store the InstantArticle wrapper object on the node entity to allow
-        // field formatters and others to make changes/additions to it until it's
-        // finally rendered out in hook_preprocess_node().
-        $node->fb_instant_articles_display_wrapper = $wrapper;
-      }
+    if(in_array($node->type, $enabled_bundles)) {
+      $layout_settings = fb_instant_articles_display_get_node_layout_settings($node->type);
+      $node->fb_instant_articles_display_wrapper = \Drupal\fb_instant_articles_display\DrupalInstantArticleDisplay::create($node, $layout_settings);
     }
   }
 }

--- a/modules/fb_instant_articles_display/fb_instant_articles_display.module
+++ b/modules/fb_instant_articles_display/fb_instant_articles_display.module
@@ -176,14 +176,21 @@ function fb_instant_articles_display_entity_info_alter(&$entity_info) {
 }
 
 /**
- * Implements hook_node_view().
+ * Implements hook_node_load().
  */
-function fb_instant_articles_display_node_view($node, $view_mode, $langcode) {
-  if ($view_mode == 'fb_instant_article' && $enabled_entity_types = fb_instant_articles_display_get_article_entity_types()) {
+function fb_instant_articles_display_node_load($nodes, $types) {
+  if ($enabled_entity_types = fb_instant_articles_display_get_article_entity_types()) {
     $enabled_bundles = array_keys($enabled_entity_types['node']);
-    if(in_array($node->type, $enabled_bundles)) {
-      $layout_settings = fb_instant_articles_display_get_node_layout_settings($node->type);
-      $node->fb_instant_articles_display_wrapper = \Drupal\fb_instant_articles_display\DrupalInstantArticleDisplay::create($node, $layout_settings);
+
+    if (!empty($enabled_bundles) && count(array_intersect($enabled_bundles, $types))) {
+      foreach ($nodes as $node) {
+        $layout_settings = fb_instant_articles_display_get_node_layout_settings($node->type);
+        $wrapper = \Drupal\fb_instant_articles_display\DrupalInstantArticleDisplay::create($node, $layout_settings);
+        // Store the InstantArticle wrapper object on the node entity to allow
+        // field formatters and others to make changes/additions to it until it's
+        // finally rendered out in hook_preprocess_node().
+        $node->fb_instant_articles_display_wrapper = $wrapper;
+      }
     }
   }
 }


### PR DESCRIPTION
Moved the DrupalInstantArticleDisplay class built to `hook_node_view` instead of `hook_node_load`. Because `hook_node_load` won't be fired when we adding the content. Like node insert. Since we are using the `node_build_content` or `node_view` in API module and RSS module it makes me feel appropriate to move this. 
This is reference to #52 
