### PR TITLE
Issue #2726761: add a default rule to transform div's to paragraphs to cover a common case and avoid an empty article transform.

### DIFF
--- a/modules/fb_instant_articles_display/transformer_config.json
+++ b/modules/fb_instant_articles_display/transformer_config.json
@@ -21,6 +21,9 @@
     "selector": "span"
   }, {
     "class": "ParagraphRule",
+    "selector": "div"
+  }, {
+    "class": "ParagraphRule",
     "selector": "p"
   }, {
     "class": "LineBreakRule",


### PR DESCRIPTION
Resolves https://www.drupal.org/node/2726761.
