### PR TITLE
Issue #2726761: add a default rule to transform div's to paragraphs to cover a common case and avoid an empty article transform.  Adapted for 7.x-2.x.

### DIFF
--- a/fb_instant_articles.module
+++ b/fb_instant_articles.module
@@ -223,6 +223,10 @@ function fb_instant_articles_fb_instant_articles_transformer_rules() {
     ),
     array(
       'class' => 'ParagraphRule',
+      'selector' => 'div',
+    ),
+    array(
+      'class' => 'ParagraphRule',
       'selector' => 'p',
     ),
     array(


### PR DESCRIPTION
Resolves https://www.drupal.org/node/2726761 for 7.x-2.x
