### PR TITLE
Issue #2749119 by ryanissamson: Adds variable that overrides base canonical url

### DIFF
--- a/fb_instant_articles.install
+++ b/fb_instant_articles.install
@@ -19,6 +19,7 @@ function fb_instant_articles_uninstall() {
   variable_del('fb_instant_articles_analytics_embed_code');
   variable_del('fb_instant_articles_enable_logging');
   variable_del('fb_instant_articles_bypass_composer_manager');
+  variable_del('fb_instant_articles_canonical_url_override');
 }
 
 /**

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -51,6 +51,14 @@ function fb_instant_articles_settings() {
     '#description' => t('Sends Facebook Instant Articles SDK logging messages to Drupal watchdog.'),
   );
 
+  // Add the Canonical URL override.
+  $form['fb_instant_articles_canonical_url_override'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Canonical URL override'),
+    '#default_value' => variable_get('fb_instant_articles_canonical_url_override', ''),
+    '#description' => t('If you need to override the base url portion of the canonical URL, you can do so here. This may be helpful for development domains or necessary if admin users perform tasks that trigger Facebook requests from alternate domains. This URL should not include a trailing slash (e.g. http://drupal.org).'),
+  );
+
   $form = system_settings_form($form);
   return $form;
 }

--- a/modules/fb_instant_articles_display/src/EntityPropertyMapper.php
+++ b/modules/fb_instant_articles_display/src/EntityPropertyMapper.php
@@ -80,8 +80,15 @@ class EntityPropertyMapper {
   }
 
   private function addCanonicalURL() {
+    $canonical_override = variable_get('fb_instant_articles_canonical_url_override', '');
     $path = entity_uri($this->entity_type, $this->entity);
-    $this->instantArticle->withCanonicalUrl(url($path['path'], array('absolute' => TRUE)));
+    if (empty($canonical_override)) {
+      $canonical_url = url($path['path'], array('absolute' => TRUE));
+    }
+    else {
+      $canonical_url = $canonical_override . url($path['path']);
+    }
+    $this->instantArticle->withCanonicalUrl($canonical_url);
   }
 
   private function addHeaderFromProperties() {


### PR DESCRIPTION
- If a url is supplied, the base portion is overridden.
- This could probably be improved with validation on
  the field to prevent malformed urls.

https://www.drupal.org/node/2749119
