### PR TITLE
Issue #2750353 Adds check to see if $item['url'] already exists

### DIFF
--- a/modules/fb_instant_articles_display/src/DrupalInstantArticleDisplay.php
+++ b/modules/fb_instant_articles_display/src/DrupalInstantArticleDisplay.php
@@ -555,8 +555,10 @@ class DrupalInstantArticleDisplay {
    */
   private function fieldFormatVideoElement($items, $region, $settings) {
     foreach ($items as $delta => $item) {
+      // A video url may already be provided for external videos files.
+      $video_url = !empty($item['url']) ? $item['url'] : file_create_url($item['uri']);
       $video = Video::create()
-        ->withURL(file_create_url($item['uri']));
+        ->withURL($video_url);
 
       if ($region instanceof Header) {
         $region->withCover($video);


### PR DESCRIPTION
- This is related to
  https://github.com/BurdaMagazinOrg/module-fb_instant_articles/pull/74
- We were altering a reference field and the data passed in
  already had a URL and no URI, so this just prevents this
  failing the check.
  
  https://www.drupal.org/node/2750353
