### PR TITLE
Issue #2750353: Add check to fieldFormatVideoElement in case $video_url is provided to function

### DIFF
--- a/modules/fb_instant_articles_display/src/EntityFieldMapper.php
+++ b/modules/fb_instant_articles_display/src/EntityFieldMapper.php
@@ -482,8 +482,10 @@ class EntityFieldMapper {
    */
   private function fieldFormatVideoElement($items, Element $region, $settings) {
     foreach ($items as $delta => $item) {
+      // A video url may already be provided for external videos files.
+      $video_url = !empty($item['url']) ? $item['url'] : file_create_url($item['uri']);
       $video = Video::create()
-        ->withURL(file_create_url($item['uri']));
+        ->withURL($video_url);
 
       if ($region instanceof Header) {
         $region->withCover($video);


### PR DESCRIPTION
```
Adds a check for URL instead of just URI

- We were altering a reference field and the data passed in
already had a URL and no URI, so this just prevents this
failing the check.
```
