### PR TITLE
Remove scripts[] = js/admin.js from fb_instant_articles_display.info

### DIFF
--- a/modules/fb_instant_articles_display/fb_instant_articles_display.info
+++ b/modules/fb_instant_articles_display/fb_instant_articles_display.info
@@ -4,4 +4,3 @@ package = Facebook Instant Articles
 core = 7.x
 dependencies[] = ctools
 dependencies[] = fb_instant_articles
-scripts[] = js/admin.js


### PR DESCRIPTION
- admin.js is already added to the specific form where it is needed in the `fb_instant_articles_display_layout_form` function. (In fb_instant_articles_display/includes/view_mode_layout.inc)
- `scripts[] = js/admin.js` adds the jacascript to every page loading unecessary javascript.

https://www.drupal.org/node/2778535
