### PR TITLE
Issue #2871635 Port LoggerAppender object

### DIFF
--- a/fb_instant_articles.module
+++ b/fb_instant_articles.module
@@ -50,7 +50,7 @@ function fb_instant_articles_init() {
   $appender = array(
     'class' => $enable_transformer_logging ? '\Drupal\fb_instant_articles\DrupalLoggerAppender' : 'LoggerAppenderNull',
     'layout' => array(
-      'class' => 'LoggerLayoutSimple'
+      'class' => 'LoggerLayoutSimple',
     ),
   );
   $configuration = array(

--- a/src/DrupalLoggerAppender.php
+++ b/src/DrupalLoggerAppender.php
@@ -1,16 +1,10 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\fb_instant_articles\DrupalLoggerAppender.
- */
-
 namespace Drupal\fb_instant_articles;
 
 /**
  * Adds Drupal logging functionality to existing SDK logging.
  *
- * Class DrupalLoggerAppender
  * @package Drupal\fb_instant_articles
  *
  * @see fb_instant_articles_display_init()
@@ -23,12 +17,10 @@ class DrupalLoggerAppender extends \LoggerAppender {
    * Additionally sends logging event to Drupal watchdog.
    */
   public function append(\LoggerLoggingEvent $event) {
-    watchdog(
-      $event->getLoggerName(),
-      $event->getRenderedMessage(),
-      null,
+    \Drupal::logger($event->getLoggerName())->log(
       // Watchdog levels follow RFC 3164.
-      $event->getLevel()->getSyslogEquivalent()
+      $event->getLevel()->getSyslogEquivalent(),
+      $event->getRenderedMessage()
     );
   }
 


### PR DESCRIPTION
 Fix DrupalLoggerAppender use of watchdog which is no longer a thing in Drupal 8.