### PR TITLE
Issue #2871634 Require FBIA PHP SDK via Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,5 @@
   }],
   "require": {
     "facebook/facebook-instant-articles-sdk-php": "^1.0.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "Drupal\\fb_instant_articles\\": "src/"
-    }
   }
 }


### PR DESCRIPTION
Remove autoload property in composer.json, no longer needed.