### PR TITLE
Issue #2872801 Add custom view mode to the base module.

### DIFF
--- a/config/install/core.entity_view_mode.node.facebook_instant_articles.yml
+++ b/config/install/core.entity_view_mode.node.facebook_instant_articles.yml
@@ -1,0 +1,12 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+  enforced:
+    module:
+      - fb_instant_articles
+id: node.fb_instant_articles
+label: Facebook Instant Articles
+targetEntityType: node
+cache: true

--- a/config/schema/fb_instant_articles.schema.yml
+++ b/config/schema/fb_instant_articles.schema.yml
@@ -1,0 +1,7 @@
+node.type.*.third_party.fb_instant_articles:
+  type: mapping
+  label: 'Facebook Instant Articles'
+  mapping:
+    fb_instant_articles_enabled:
+      type: boolean
+      label: 'Whether to enable Facebook Instant Articles for this content type'

--- a/fb_instant_articles.module
+++ b/fb_instant_articles.module
@@ -6,6 +6,9 @@
  */
 
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeTypeInterface;
+use Drupal\Core\Entity\Entity\EntityViewDisplay;
 
 /**
  * Implements hook_help().
@@ -66,4 +69,67 @@ function fb_instant_articles_init() {
     ),
   );
   \Logger::configure($configuration);
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter() for \Drupal\node\NodeTypeForm.
+ *
+ * @see fb_instant_articles_form_node_type_form_builder()
+ */
+function fb_instant_articles_form_node_type_form_alter(&$form, FormStateInterface $form_state) {
+  /** @var \Drupal\node\NodeTypeInterface $node_type */
+  $node_type = $form_state->getFormObject()->getEntity();
+
+  // Add a vertical tab to the node type form.
+  $form['fb_instant_articles'] = [
+    '#type' => 'details',
+    '#title' => t('Facebook Instant Articles'),
+    '#group' => 'additional_settings',
+    '#access' => \Drupal::currentUser()->hasPermission('administer fb_instant_articles'),
+  ];
+
+  // Facebook Instant Articles enabled checkbox.
+  $form['fb_instant_articles']['fb_instant_articles_enabled'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Enable Facebook Instant Articles'),
+    '#description' => t('Enable content of this type with support for Facebook Instant Articles.'),
+    '#weight' => 0,
+    '#default_value' => $node_type->getThirdPartySetting('fb_instant_articles', 'fb_instant_articles_enabled'),
+  ];
+
+  $form['#entity_builders'][] = 'fb_instant_articles_form_node_type_form_builder';
+}
+
+/**
+ * Entity builder for the node type form with the FBIA toggle.
+ *
+ * @see fb_instant_articles_display_form_node_type_form_alter()
+ */
+function fb_instant_articles_form_node_type_form_builder($entity_type, NodeTypeInterface $type, &$form, FormStateInterface $form_state) {
+  if ($form_state->getValue('fb_instant_articles_enabled') === 1) {
+    /** @var \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display */
+    if ($display = \Drupal::entityTypeManager()->getStorage('entity_view_display')->load('node.' . $type->id() . '.fb_instant_articles')) {
+      $display->setStatus(TRUE)
+        ->save();
+    }
+    else {
+      $display = new EntityViewDisplay([
+        'id' => 'node.' . $type->id() . '.fb_instant_articles',
+        'targetEntityType' => 'node',
+        'bundle' => $type->id(),
+        'mode' => 'fb_instant_articles',
+        'status' => TRUE,
+      ], 'entity_view_display');
+      $display->save();
+    }
+    $type->setThirdPartySetting('fb_instant_articles', 'fb_instant_articles_enabled', 1);
+  }
+  else {
+    /** @var \Drupal\Core\Entity\Display\EntityDisplayInterface $display */
+    if ($display = \Drupal::entityTypeManager()->getStorage('entity_view_display')->load('node.' . $type->id() . '.fb_instant_articles')) {
+      $display->setStatus(FALSE)
+        ->save();
+    }
+    $type->unsetThirdPartySetting('fb_instant_articles', 'fb_instant_articles_enabled');
+  }
 }

--- a/fb_instant_articles.permissions.yml
+++ b/fb_instant_articles.permissions.yml
@@ -1,0 +1,2 @@
+administer fb_instant_articles:
+  title: 'Administer Facebook Instant Articles'

--- a/tests/src/Functional/FbiaViewModeToggleTest.php
+++ b/tests/src/Functional/FbiaViewModeToggleTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Drupal\Tests\fb_instant_articles\Functional;
+
+use Drupal\Core\Url;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests the view mode toggle functionality.
+ *
+ * @group fb_instant_articles
+ */
+class FbiaViewModeToggleTest extends BrowserTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'fb_instant_articles',
+    'node',
+    'field_ui',
+  ];
+
+  /**
+   * Permissions to grant admin user.
+   *
+   * @var array
+   */
+  protected $permissions = [
+    'access administration pages',
+    'administer content types',
+    'administer display modes',
+    'administer node display',
+    'administer site configuration',
+    'administer fb_instant_articles',
+  ];
+
+  /**
+   * An user with administration permissions.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    // Create Article node type.
+    $this->createContentType([
+      'type' => 'article',
+      'name' => 'Article',
+    ]);
+  }
+
+  /**
+   * Test the FBIA view mode toggle.
+   */
+  public function testFbiaViewModeToggle() {
+
+    // Login as an admin user.
+    $this->adminUser = $this->drupalCreateUser($this->permissions);
+    $this->drupalLogin($this->adminUser);
+
+    // Check that the FBIA view mode is available.
+    $view_modes_url = Url::fromRoute('entity.entity_view_mode.collection')->toString();
+    $this->drupalGet($view_modes_url);
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('Facebook Instant Articles');
+
+    // Enable FBIA display on article content.
+    $article_url = Url::fromRoute('entity.node_type.edit_form', ['node_type' => 'article'])->toString();
+    $this->drupalGet($article_url);
+    $this->assertSession()->statusCodeEquals(200);
+    $edit = ['fb_instant_articles_enabled' => '1'];
+    $this->submitForm($edit, t('Save content type'));
+
+    // Check that the FBIA view mode has been turned on.
+    $article_display_url = Url::fromRoute('entity.entity_view_display.node.default', ['node_type' => 'article'])->toString();
+    $this->drupalGet($article_display_url);
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->checkboxChecked('edit-display-modes-custom-fb-instant-articles');
+
+    // Disable the FBIA view mode.
+    $article_url = Url::fromRoute('entity.node_type.edit_form', ['node_type' => 'article'])->toString();
+    $this->drupalGet($article_url);
+    $this->assertSession()->statusCodeEquals(200);
+    $edit = ['fb_instant_articles_enabled' => '0'];
+    $this->submitForm($edit, t('Save content type'));
+
+    // Check that the FBIA view mode has been turned off.
+    $article_display_url = Url::fromRoute('entity.entity_view_display.node.default', ['node_type' => 'article'])->toString();
+    $this->drupalGet($article_display_url);
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->checkboxNotChecked('edit-display-modes-custom-fb-instant-articles');
+  }
+
+}


### PR DESCRIPTION
Adds the view mode for Facebook Instant Articles. Introduces a toggle per bundle as a helper to enable the fb_instant_articles view mode.

To test:

 - [ ] Enable `fb_instant_articles` module. If already enabled, you'll need to uninstall, reinstall.
 - [ ] Verify you get the Facebook Instant Articles view mode on node types
 - [ ] On the node bundle edit page, click the Facebook Instant Articles vertical tab, and enable the checkbox. This should enable/disable the Facebook Instant Articles view mode for the bundle.