### PR TITLE
Issue #2872804 Customize the Manage Display UI for the custom view mode to allow multiple regions

### DIFF
--- a/fb_instant_articles.info.yml
+++ b/fb_instant_articles.info.yml
@@ -4,3 +4,5 @@ description: Base module for Facebook Instant Articles.
 core: 8.x
 package: Facebook Instant Articles
 configure: fb_instant_articles.config
+dependencies:
+  - drupal:system (>= 8.3.x)

--- a/fb_instant_articles.module
+++ b/fb_instant_articles.module
@@ -133,3 +133,11 @@ function fb_instant_articles_form_node_type_form_builder($entity_type, NodeTypeI
     $type->unsetThirdPartySetting('fb_instant_articles', 'fb_instant_articles_enabled');
   }
 }
+
+/**
+ * Implements hook_entity_type_alter().
+ */
+function fb_instant_articles_entity_type_alter(array &$entity_types) {
+  /** @var \Drupal\Core\Entity\EntityTypeInterface[] $entity_types */
+  $entity_types['entity_view_display']->setFormClass('edit', 'Drupal\fb_instant_articles\Form\EntityViewDisplayEditForm');
+}

--- a/src/Form/EntityViewDisplayEditForm.php
+++ b/src/Form/EntityViewDisplayEditForm.php
@@ -3,11 +3,25 @@
 namespace Drupal\fb_instant_articles\Form;
 
 use Drupal\field_ui\Form\EntityViewDisplayEditForm as CoreEntityViewDisplayEditForm;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
 
 /**
  * Extends the core EntityViewDisplayEditForm to support multiple regions.
  */
 class EntityViewDisplayEditForm extends CoreEntityViewDisplayEditForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTableHeader() {
+    $table_headers = parent::getTableHeader();
+    if ($this->getEntity()->getOriginalMode() === 'fb_instant_articles') {
+      $region = $this->t('Region');
+      array_splice($table_headers, 1, 0, array($region));
+    }
+    return $table_headers;
+  }
 
   /**
    * {@inheritdoc}
@@ -31,6 +45,41 @@ class EntityViewDisplayEditForm extends CoreEntityViewDisplayEditForm {
       $regions = $new_regions;
     }
     return $regions;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildFieldRow(FieldDefinitionInterface $field_definition, array $form, FormStateInterface $form_state) {
+    $field_row = parent::buildFieldRow($field_definition, $form, $form_state);
+
+    $field_name = $field_definition->getName();
+    $display_options = $this->entity->getComponent($field_name);
+    if ($this->getEntity()->getOriginalMode() === 'fb_instant_articles') {
+      // Insert the label column.
+      $region = array(
+        'region_column' => array(
+          '#type' => 'select',
+          '#title' => $this->t('Label display for @title', array('@title' => $field_definition->getLabel())),
+          '#title_display' => 'invisible',
+          '#options' => ['Header',
+                         'Body',
+                         'Footer',
+          ],
+          '#default_value' => $display_options ? $display_options['label'] : 'above',
+        ),
+      );
+      $label_position = array_search('label', array_keys($field_row));
+      $field_row = array_slice($field_row, 0, $label_position, TRUE) + $region + array_slice($field_row, $label_position, count($field_row) - 1, TRUE);
+      // Update the (invisible) title of the 'plugin' column.
+      $field_row['plugin']['#title'] = $this->t('Formatter for @title', array('@title' => $field_definition->getLabel()));
+      if (!empty($field_row['plugin']['settings_edit_form']) && ($plugin = $this->entity->getRenderer($field_name))) {
+        $plugin_type_info = $plugin->getPluginDefinition();
+        $field_row['plugin']['settings_edit_form']['label']['#markup'] = $this->t('Format settings:') . ' <span class="plugin-name">' . $plugin_type_info['label'] . '</span>';
+      }
+    }
+
+    return $field_row;
   }
 
 }

--- a/src/Form/EntityViewDisplayEditForm.php
+++ b/src/Form/EntityViewDisplayEditForm.php
@@ -3,25 +3,11 @@
 namespace Drupal\fb_instant_articles\Form;
 
 use Drupal\field_ui\Form\EntityViewDisplayEditForm as CoreEntityViewDisplayEditForm;
-use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Field\FieldDefinitionInterface;
 
 /**
  * Extends the core EntityViewDisplayEditForm to support multiple regions.
  */
 class EntityViewDisplayEditForm extends CoreEntityViewDisplayEditForm {
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getTableHeader() {
-    $table_headers = parent::getTableHeader();
-    if ($this->getEntity()->getOriginalMode() === 'fb_instant_articles') {
-      $region = $this->t('Region');
-      array_splice($table_headers, 1, 0, array($region));
-    }
-    return $table_headers;
-  }
 
   /**
    * {@inheritdoc}
@@ -45,41 +31,6 @@ class EntityViewDisplayEditForm extends CoreEntityViewDisplayEditForm {
       $regions = $new_regions;
     }
     return $regions;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function buildFieldRow(FieldDefinitionInterface $field_definition, array $form, FormStateInterface $form_state) {
-    $field_row = parent::buildFieldRow($field_definition, $form, $form_state);
-
-    $field_name = $field_definition->getName();
-    $display_options = $this->entity->getComponent($field_name);
-    if ($this->getEntity()->getOriginalMode() === 'fb_instant_articles') {
-      // Insert the label column.
-      $region = array(
-        'region_column' => array(
-          '#type' => 'select',
-          '#title' => $this->t('Label display for @title', array('@title' => $field_definition->getLabel())),
-          '#title_display' => 'invisible',
-          '#options' => ['Header',
-                         'Body',
-                         'Footer',
-          ],
-          '#default_value' => $display_options ? $display_options['label'] : 'above',
-        ),
-      );
-      $label_position = array_search('label', array_keys($field_row));
-      $field_row = array_slice($field_row, 0, $label_position, TRUE) + $region + array_slice($field_row, $label_position, count($field_row) - 1, TRUE);
-      // Update the (invisible) title of the 'plugin' column.
-      $field_row['plugin']['#title'] = $this->t('Formatter for @title', array('@title' => $field_definition->getLabel()));
-      if (!empty($field_row['plugin']['settings_edit_form']) && ($plugin = $this->entity->getRenderer($field_name))) {
-        $plugin_type_info = $plugin->getPluginDefinition();
-        $field_row['plugin']['settings_edit_form']['label']['#markup'] = $this->t('Format settings:') . ' <span class="plugin-name">' . $plugin_type_info['label'] . '</span>';
-      }
-    }
-
-    return $field_row;
   }
 
 }

--- a/src/Form/EntityViewDisplayEditForm.php
+++ b/src/Form/EntityViewDisplayEditForm.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\fb_instant_articles\Form;
+
+use Drupal\field_ui\Form\EntityViewDisplayEditForm as CoreEntityViewDisplayEditForm;
+
+/**
+ * Extends the core EntityViewDisplayEditForm to support multiple regions.
+ */
+class EntityViewDisplayEditForm extends CoreEntityViewDisplayEditForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRegions() {
+    $regions = parent::getRegions();
+    if ($this->getEntity()->getOriginalMode() === 'fb_instant_articles') {
+      $new_regions['header'] = [
+        'title' => $this->t('Header'),
+        'message' => $this->t('No fields are displayed in this region.'),
+      ];
+      $new_regions['content'] = [
+        'title' => $this->t('Body'),
+        'message' => $this->t('No fields are displayed in this region.'),
+      ];
+      $new_regions['footer'] = [
+        'title' => $this->t('Footer'),
+        'message' => $this->t('No fields are displayed in this region.'),
+      ];
+      $new_regions['hidden'] = $regions['hidden'];
+      $regions = $new_regions;
+    }
+    return $regions;
+  }
+
+}


### PR DESCRIPTION
This PR adds the customizations to Manage Display UI for the FB Instant Articles view mode. To test:

 - [x] Enable the fb_instant_articles
 - [x] Toggle FB Instant Articles on for the Article content type for example
 - [x] Visit the Manage Display UI for the Article content type. You should see Header/Body/Footer regions. You should be able to drag fields into each, Save and the fields should persist in those regions.