### PR TITLE
Issue #2871641 Add admin page for configuring API credentials

### DIFF
--- a/config/schema/fb_instant_articles.schema.yml
+++ b/config/schema/fb_instant_articles.schema.yml
@@ -1,3 +1,48 @@
+fb_instant_articles.base_settings:
+  type: config_object
+  mapping:
+    page_id:
+      type: string
+      label: 'Page ID'
+    page_name:
+      type: string
+      label: 'Page Name'
+    style:
+      type: string
+      label: 'Style'
+    ads:
+      type: mapping
+      label: 'Ads settings'
+      mapping:
+        type:
+          type: string
+          label: 'Ad type'
+        iframe_url:
+          type: uri
+          label: 'Ad source URL'
+        an_placement_id:
+          type: string
+          label: 'Audience network placement ID'
+        embed_code:
+          type: string
+          label: 'Ad embed code'
+        dimensions:
+          type: string
+          label: 'Ad dimensions'
+    analytics:
+      type: mapping
+      label: 'Analytics settings'
+      mapping:
+        embed_code:
+          type: string
+          label: 'Analytics embed code'
+    enable_logging:
+      type: integer
+      label: 'Enable FB Instant Articles SDK logging'
+    canonical_url_override:
+      type: uri
+      label: 'Canonical URL override'
+
 node.type.*.third_party.fb_instant_articles:
   type: mapping
   label: 'Facebook Instant Articles'

--- a/fb_instant_articles.links.task.yml
+++ b/fb_instant_articles.links.task.yml
@@ -1,0 +1,4 @@
+fb_instant_articles.base_settings_tab:
+  route_name: fb_instant_articles.base_settings_form
+  title: 'Base settings'
+  base_route: fb_instant_articles.base_settings_form

--- a/fb_instant_articles.routing.yml
+++ b/fb_instant_articles.routing.yml
@@ -4,6 +4,6 @@ fb_instant_articles.base_settings_form:
     _form: '\Drupal\fb_instant_articles\Form\BaseSettingsForm'
     _title: 'Facebook Instant Articles Base Settings'
   requirements:
-    _permission: 'access administration pages'
+    _permission: 'administer fb_instant_articles'
   options:
     _admin_route: TRUE

--- a/modules/fb_instant_articles_api/config/schema/fb_instant_articles_api.schema.yml
+++ b/modules/fb_instant_articles_api/config/schema/fb_instant_articles_api.schema.yml
@@ -1,0 +1,15 @@
+fb_instant_articles_api.settings:
+  type: config_object
+  mapping:
+    app_id:
+      type: string
+      label: 'App ID'
+    app_secret:
+      type: string
+      label: 'App secret'
+    access_token:
+      type: string
+      label: 'Access token'
+    page_access_token:
+      type: string
+      label: 'Page access token'

--- a/modules/fb_instant_articles_api/fb_instant_articles_api.info.yml
+++ b/modules/fb_instant_articles_api/fb_instant_articles_api.info.yml
@@ -1,0 +1,7 @@
+name: Facebook Instant Articles API
+type: module
+description: API module for Facebook Instant Articles.
+core: 8.x
+package: Facebook Instant Articles
+dependencies:
+  - fb_instant_articles

--- a/modules/fb_instant_articles_api/fb_instant_articles_api.links.task.yml
+++ b/modules/fb_instant_articles_api/fb_instant_articles_api.links.task.yml
@@ -1,0 +1,4 @@
+fb_instant_articles_api.settings_tab:
+  route_name: fb_instant_articles_api.settings_form
+  title: 'API settings'
+  base_route: fb_instant_articles.base_settings_form

--- a/modules/fb_instant_articles_api/fb_instant_articles_api.module
+++ b/modules/fb_instant_articles_api/fb_instant_articles_api.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Hook implemetations for Facebook Instant Articles API module.
+ */

--- a/modules/fb_instant_articles_api/fb_instant_articles_api.routing.yml
+++ b/modules/fb_instant_articles_api/fb_instant_articles_api.routing.yml
@@ -7,3 +7,12 @@ fb_instant_articles_api.settings_form:
     _permission: 'administer fb_instant_articles'
   options:
     _admin_route: TRUE
+fb_instant_articles_api.login_callback:
+  path: 'admin/config/services/fb_instant_articles/api/login'
+  defaults:
+    _title: 'Facebook login callback'
+    _controller: '\Drupal\fb_instant_articles_api\Controller\ApiController::facebookLogin'
+  requirements:
+    _permission: 'administer fb_instant_articles'
+  options:
+    _admin_route: TRUE

--- a/modules/fb_instant_articles_api/fb_instant_articles_api.routing.yml
+++ b/modules/fb_instant_articles_api/fb_instant_articles_api.routing.yml
@@ -1,0 +1,9 @@
+fb_instant_articles_api.settings_form:
+  path: '/admin/config/services/fb_instant_articles/api_settings'
+  defaults:
+    _form: '\Drupal\fb_instant_articles_api\Form\ApiSettingsForm'
+    _title: 'Facebook Instant Articles API Settings'
+  requirements:
+    _permission: 'administer fb_instant_articles'
+  options:
+    _admin_route: TRUE

--- a/modules/fb_instant_articles_api/src/Controller/ApiController.php
+++ b/modules/fb_instant_articles_api/src/Controller/ApiController.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Drupal\fb_instant_articles_api\Controller;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Url;
+use Facebook\Exceptions\FacebookResponseException;
+use Facebook\Exceptions\FacebookSDKException;
+use Facebook\Facebook;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Controller to handle Facebook login callback.
+ */
+class ApiController extends ControllerBase {
+
+  /**
+   * Config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Creates a new \Drupal\fb_instant_articles_api\Controller\ApiController.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   Config factory service.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * Handle Facebook login callback.
+   */
+  public function facebookLogin() {
+    $config = $this->configFactory->getEditable('fb_instant_articles_api.settings');
+    $fb = new Facebook([
+      'app_id' => $config->get('app_id'),
+      'app_secret' => $config->get('app_secret'),
+      'default_graph_version' => 'v2.5',
+    ]);
+    $helper = $fb->getRedirectLoginHelper();
+
+    // Grab the user access token based on callback response and report back an
+    // error if we weren't able to get one.
+    try {
+      $access_token = $helper->getAccessToken();
+
+      if ($access_token == NULL) {
+        $error_msg = $this->t('We failed to authenticate your Facebook account with this module. Please try again.');
+        drupal_set_message($error_msg, 'error');
+      }
+      else {
+        // Confirm that the person granted the necessary permissions before
+        // proceeding.
+        $permissions = $fb->get('/me/permissions', $access_token)
+          ->getGraphEdge();
+        $rejected_permissions = [];
+        foreach ($permissions as $permission) {
+          if ($permission->getField('status') != 'granted') {
+            $rejected_permissions[] = $permission->getField('permission');
+          }
+        }
+        if (!empty($rejected_permissions)) {
+          $error_msg = $this->t('You did not grant the following required permissions in the Facebook authentication process: @permissions. Please try again.', ['@permissions' => implode(', ', $rejected_permissions)]);
+          drupal_set_message($error_msg, 'error');
+        }
+        else {
+          // Store this user access token to the database.
+          $config
+            ->set('access_token', $access_token->getValue())
+            ->save();
+          drupal_set_message('Facebook authentication was successful. Access token obtained.');
+        }
+      }
+    }
+    catch (FacebookResponseException $e) {
+      $error_msg = $this->t('We received the following error while attempting to authenticate your Facebook account: @error', ['@error' => $e->getMessage()]);
+      drupal_set_message($error_msg, 'error');
+    }
+    catch (FacebookSDKException $e) {
+      $error_msg = $this->t('We received the following error while attempting to authenticate your Facebook account: @error', ['@error' => $e->getMessage()]);
+      drupal_set_message($error_msg, 'error');
+    }
+
+    return new RedirectResponse(Url::fromRoute('fb_instant_articles_api.settings_form')->toString());
+  }
+
+}

--- a/modules/fb_instant_articles_api/src/Form/ApiSettingsForm.php
+++ b/modules/fb_instant_articles_api/src/Form/ApiSettingsForm.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\fb_instant_articles_api\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Facebook Instant Articles API form.
+ */
+class ApiSettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'fb_instant_articles_api.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'api_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('fb_instant_articles_api.settings');
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+
+  }
+
+}

--- a/modules/fb_instant_articles_api/src/Form/ApiSettingsForm.php
+++ b/modules/fb_instant_articles_api/src/Form/ApiSettingsForm.php
@@ -125,7 +125,7 @@ class ApiSettingsForm extends ConfigFormBase {
     }
     // Everything's been configured, so let's provide the summary view.
     else {
-      $form = $this->moduleActivationSummary($form, $app_id);
+      $form = $this->moduleActivationSummary($form, $app_id, $page_id);
     }
     return $form;
   }
@@ -391,11 +391,13 @@ class ApiSettingsForm extends ConfigFormBase {
    *   FAPI array.
    * @param string $app_id
    *   Facebook application id.
+   * @param string $page_id
+   *   Facebook page id.
    *
    * @return array
    *   FAPI array.
    */
-  protected function moduleActivationSummary(array $form, $app_id) {
+  protected function moduleActivationSummary(array $form, $app_id, $page_id) {
     $page_name = $this->config('fb_instant_articles.base_settings')->get('page_name');
 
     $form['module_activation'] = [
@@ -403,11 +405,17 @@ class ApiSettingsForm extends ConfigFormBase {
       '#title' => t('Module activation'),
       '#open' => TRUE,
     ];
+    $markup = [
+      '<p>' . $this->t('Your Facebook App ID is <strong>@app_id</strong>. <a href="?edit=fb_app_settings">Update Facebook app id</a>.', ['@app_id' => $app_id]) . '</p>',
+    ];
+    if ($page_name) {
+      $markup[] = '<p>' . $this->t('Your Facebook Page is <strong>@page_name</strong>. <a href="?edit=fb_page">Update facebook page</a>.', ['@page_name' => $page_name]) . '</p>';
+    }
+    elseif ($page_id) {
+      $markup[] = '<p>' . $this->t('Your Facebook Page ID is <strong>@page_id</strong>. <a href="?edit=fb_page">Update facebook page</a>.', ['@page_id' => $page_id]) . '</p>';
+    }
     $form['module_activation']['fb_app_settings'] = [
-      '#markup' => '
-        <p>' . $this->t('Your Facebook App ID is <strong>@app_id</strong>. <a href="?edit=fb_app_settings">Update Facebook app id</a>.', ['@app_id' => $app_id]) . '</p>
-        <p>' . $this->t('Your Facebook Page is <strong>@page_name</strong>. <a href="?edit=fb_page">Update facebook page id</a>.', ['@page_name' => $page_name]) . '</p>
-      ',
+      '#markup' => implode('', $markup),
     ];
 
     return $form;

--- a/modules/fb_instant_articles_api/src/Form/ApiSettingsForm.php
+++ b/modules/fb_instant_articles_api/src/Form/ApiSettingsForm.php
@@ -2,8 +2,15 @@
 
 namespace Drupal\fb_instant_articles_api\Form;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Facebook\Authentication\AccessToken;
+use Facebook\Facebook;
+use Facebook\InstantArticles\Client\Helper;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Facebook Instant Articles API form.
@@ -11,11 +18,42 @@ use Drupal\Core\Form\FormStateInterface;
 class ApiSettingsForm extends ConfigFormBase {
 
   /**
+   * Current request object.
+   *
+   * @var \Symfony\Component\HttpFoundation\Request
+   */
+  protected $currentRequest;
+
+  /**
+   * Constructs a \Drupal\fb_instant_articles_api\ApiSettingsForm object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Symfony\Component\HttpFoundation\Request $current_request
+   *   Current request object.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, Request $current_request) {
+    parent::__construct($config_factory);
+    $this->currentRequest = $current_request;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('request_stack')->getCurrentRequest()
+    );
+  }
+
+  /**
    * {@inheritdoc}
    */
   protected function getEditableConfigNames() {
     return [
       'fb_instant_articles_api.settings',
+      'fb_instant_articles.base_settings',
     ];
   }
 
@@ -30,7 +68,375 @@ class ApiSettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $config = $this->config('fb_instant_articles_api.settings');
+
+    // Generate the module activation section of the settings form.
+    $form = $this->moduleActivationBuildForm($form, $form_state);
+
+    // Add the publishing settings sub-section.
+    $form = $this->moduleConfigPublishingBuildForm($form, $form_state);
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * Generate the module activation section of the settings form.
+   *
+   * @param array $form
+   *   Form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state.
+   *
+   * @return array
+   *   Form array.
+   */
+  protected function moduleActivationBuildForm(array $form, FormStateInterface $form_state) {
+
+    // If the person is coming back to edit FB app settings, drop them back into
+    // the correct state.
+    $edit_state = '';
+    if ($edit = $this->currentRequest->get('edit')) {
+      $edit_state = $edit;
+    }
+
+    $base_config = $this->config('fb_instant_articles.base_settings');
+    $api_config = $this->config('fb_instant_articles_api.settings');
+
+    // Grab the current module settings from the database to determine where
+    // the person is in the configuration state.
+    $app_id = $api_config->get('app_id');
+    $app_secret = $api_config->get('app_secret');
+    $access_token = trim($api_config->get('access_token'));
+    $page_id = $base_config->get('page_id');
+
+    // If the App ID or App Secret haven't been configured for the module yet,
+    // drop the person into the initial state.
+    if (empty($app_id) || empty($app_secret) || $edit_state === 'fb_app_settings') {
+      $form = $this->moduleActivationFbAppSettings($form, $app_id, $app_secret);
+    }
+    // If we don't have the access token yet, have the person connect their
+    // Facebook account next.
+    elseif (empty($access_token)) {
+      $form = $this->moduleActivationConnectFbAccount($form, $app_id, $app_secret);
+    }
+    // If we have access token but not selected page ID, have the person
+    // select the page next.
+    elseif (empty($page_id) || $edit_state === 'fb_page') {
+      $form = $this->moduleActivationSelectFbPage($form, $app_id, $app_secret, $access_token, $page_id);
+    }
+    // Everything's been configured, so let's provide the summary view.
+    else {
+      $form = $this->moduleActivationSummary($form, $app_id);
+    }
+    return $form;
+  }
+
+  /**
+   * Generates state of FB account connection for Module Activation section.
+   *
+   * @param array $form
+   *   FAPI array.
+   * @param string $app_id
+   *   Facebook application id.
+   * @param string $app_secret
+   *   Facebook application secret.
+   *
+   * @return array
+   *   FAPI array.
+   */
+  protected function moduleActivationFbAppSettings(array $form, $app_id, $app_secret) {
+    $form['module_activation'] = [
+      '#type' => 'details',
+      '#title' => t('Module activation'),
+      '#description' => $this->t('You need a Facebook App to publish Instant Articles using this module. If you already have one, input the App ID and App Secret below, which you can find by clicking on your app <a href="https://developers.facebook.com/apps">here</a>. If you don\'t, <a href="https://developers.facebook.com/apps">create one here </a> before continuing.'),
+      '#open' => TRUE,
+    ];
+
+    $form['module_activation']['app_id'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('App ID'),
+      '#default_value' => $app_id,
+      '#size' => 30,
+      '#element_validate' => [
+        [$this, 'validateFbAppId'],
+      ],
+    ];
+
+    $form['module_activation']['app_secret'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('App Secret'),
+      '#default_value' => $app_secret,
+      '#size' => 30,
+    ];
+
+    $form['module_activation']['next'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Next'),
+      '#submit' => [
+        [$this, 'fbAppDetailsSubmit'],
+      ],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * Validate the Facebook application id.
+   *
+   * @param array $form
+   *   FAPI array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state.
+   */
+  public function validateFbAppId(array &$form, FormStateInterface $form_state) {
+    $app_id = $form_state->getValue('app_id');
+    if (empty($app_id)) {
+      $form_state->setErrorByName('app_id', $this->t('You must enter the App ID before proceeding.'));
+    }
+
+    if (!is_numeric($app_id)) {
+      $form_state->setErrorByName('app_id', $this->t('The App ID that you entered is invalid.'));
+    }
+  }
+
+  /**
+   * Form submission handler.
+   *
+   * @param array $form
+   *   FAPI array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state.
+   */
+  public function fbAppDetailsSubmit(array &$form, FormStateInterface $form_state) {
+    $this->config('fb_instant_articles_api.settings')
+      // Save the FB app details.
+      ->set('app_id', $form_state->getValue('app_id'))
+      ->set('app_secret', $form_state->getValue('app_secret'))
+      // Clear out the token if there was one since it's invalid now.
+      ->set('access_token', '')
+      ->set('page_access_token', '')
+      ->save();
+
+    // Clear out FB page if there was one it's invalid now.
+    $this->config('fb_instant_articles.base_settings')
+      ->set('page_id', '')
+      ->set('page_name', '')
+      ->save();
+
+    $form_state->setRedirect('fb_instant_articles_api.settings_form');
+  }
+
+  /**
+   * Generates state of FB account connection for Module Activation section.
+   *
+   * @param array $form
+   *   FAPI array.
+   * @param string $app_id
+   *   Facebook application id.
+   * @param string $app_secret
+   *   Facebook application secret.
+   *
+   * @return array
+   *   FAPI array.
+   */
+  protected function moduleActivationConnectFbAccount(array $form, $app_id, $app_secret) {
+    $fb = new Facebook([
+      'app_id' => $app_id,
+      'app_secret' => $app_secret,
+      'default_graph_version' => 'v2.5',
+    ]);
+
+    $permissions = ['pages_show_list', 'pages_manage_instant_articles'];
+    $helper = $fb->getRedirectLoginHelper();
+
+    $redirect_uri = Url::fromRoute('fb_instant_articles_api.login_callback', [], ['absolute' => TRUE])->toString();
+    $login_url = $helper->getLoginUrl($redirect_uri, $permissions);
+
+    $form['module_activation'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Module activation'),
+      '#open' => TRUE,
+    ];
+    $form['module_activation']['app_settings'] = [
+      '#markup' => '
+        <p>' . $this->t('Your Facebook App ID is <strong>@app_id</strong>. <a href="?edit=fb_app_settings">Update Facebook app id</a>.', ['@app_id' => $app_id]) . '</p>
+        <p>' . $this->t('Login to Facebook and then select the Facebook Page where you will publish Instant Articles.') . '</p>
+      ',
+    ];
+
+    $form['module_activation']['login_button'] = [
+      '#markup' => '<p>' . $this->t('<a class="button button--secondary" href="@login_url">Login with Facebook</a>', ['@login_url' => $login_url]) . '</p>',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * Generates state of FB account connection for Module Activation section.
+   *
+   * @param array $form
+   *   FAPI array.
+   * @param string $app_id
+   *   Facebook application id.
+   * @param string $app_secret
+   *   Facebook application secret.
+   * @param string $access_token
+   *   Facebook access token.
+   * @param string $page_id
+   *   Facebook page id.
+   *
+   * @return array
+   *   FAPI array.
+   */
+  protected function moduleActivationSelectFbPage(array $form, $app_id, $app_secret, $access_token, $page_id) {
+    $fb = new Facebook([
+      'app_id' => $app_id,
+      'app_secret' => $app_secret,
+      'default_graph_version' => 'v2.5',
+    ]);
+
+    $expires = time() + 60 * 60 * 2;
+    $access_token = new AccessToken($access_token, $expires);
+
+    $sdk_helper = new Helper($fb);
+    $pages = $sdk_helper->getPagesAndTokens($access_token);
+
+    $form['module_activation'] = [
+      '#type' => 'details',
+      '#title' => t('Module activation'),
+      '#open' => TRUE,
+    ];
+    $form['module_activation']['fb_app_settings'] = [
+      '#markup' => '<p>' . $this->t('Your Facebook App ID is <strong>@app_id</strong>. <a href="?edit=fb_app_settings">Update Facebook app id</a>.', ['@app_id' => $app_id]) . '</p>',
+    ];
+
+    $page_options = [];
+    foreach ($pages as $page) {
+      $page_options[$page->getField('id')] = $page->getField('name');
+    }
+
+    $form['module_activation']['page_id'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Facebook page'),
+      '#description' => $this->t('Select the Facebook page where you will publish Instant Articles.'),
+      '#options' => $page_options,
+      '#default_value' => $page_id,
+    ];
+
+    $form['module_activation']['next'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Next'),
+      '#submit' => [
+        [$this, 'fbPageSubmit'],
+      ],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * Form submission handler.
+   *
+   * @param array $form
+   *   FAPI array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state.
+   */
+  public function fbPageSubmit(array &$form, FormStateInterface $form_state) {
+    $base_config = $this->config('fb_instant_articles.base_settings');
+    $api_config = $this->config('fb_instant_articles_api.settings');
+    $app_id = $api_config->get('app_id');
+    $app_secret = $api_config->get('app_secret');
+
+    $fb = new Facebook([
+      'app_id' => $app_id,
+      'app_secret' => $app_secret,
+      'default_graph_version' => 'v2.5',
+    ]);
+
+    $access_token = $api_config->get('access_token');
+    $expires = time() + 60 * 60 * 2;
+    $access_token = new AccessToken($access_token, $expires);
+
+    $sdk_helper = new Helper($fb);
+    $pages = $sdk_helper->getPagesAndTokens($access_token);
+
+    $page_id = $form_state->getValue('page_id');
+    foreach ($pages as $page) {
+      if ($page->getField('id') === $page_id) {
+        $page_name = $page->getField('name');
+        $page_access_token = $page->getField('access_token');
+        break;
+      }
+    }
+    if ($page_name && $page_access_token) {
+      $base_config
+        ->set('page_id', $page_id)
+        ->set('page_name', $page_name)
+        ->save();
+      $api_config
+        ->set('page_access_token', $page_access_token)
+        ->save();
+      drupal_set_message('Success! This Instant Articles module has been activated.');
+      $form_state->setRedirect('fb_instant_articles_api.settings_form');
+    }
+    else {
+      drupal_set_message('There was an error connecting with your Facebook page. Try again.', 'error');
+    }
+  }
+
+  /**
+   * Generates summary state of Module Activation section.
+   *
+   * @param array $form
+   *   FAPI array.
+   * @param string $app_id
+   *   Facebook application id.
+   *
+   * @return array
+   *   FAPI array.
+   */
+  protected function moduleActivationSummary(array $form, $app_id) {
+    $page_name = $this->config('fb_instant_articles.base_settings')->get('page_name');
+
+    $form['module_activation'] = [
+      '#type' => 'details',
+      '#title' => t('Module activation'),
+      '#open' => TRUE,
+    ];
+    $form['module_activation']['fb_app_settings'] = [
+      '#markup' => '
+        <p>' . $this->t('Your Facebook App ID is <strong>@app_id</strong>. <a href="?edit=fb_app_settings">Update Facebook app id</a>.', ['@app_id' => $app_id]) . '</p>
+        <p>' . $this->t('Your Facebook Page is <strong>@page_name</strong>. <a href="?edit=fb_page">Update facebook page id</a>.', ['@page_name' => $page_name]) . '</p>
+      ',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * Add the publishing settings sub-section.
+   *
+   * @param array $form
+   *   Form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state.
+   *
+   * @return array
+   *   Form array.
+   */
+  protected function moduleConfigPublishingBuildForm(array $form, FormStateInterface $form_state) {
+    $form['module_config']['publishing'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Publishing settings'),
+      '#open' => TRUE,
+    ];
+
+    $form['module_config']['publishing']['development_mode'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Development Mode'),
+      '#default_value' => $this->config('fb_instant_articles_api.settings')->get('development_mode'),
+      '#description' => $this->t('When publishing in development, none of your articles will be made live, and they will be saved as drafts you can edit in the Instant Articles library on your Facebook Page. Whether in development mode or not, articles will not be published live until you have submitted a sample batch to Facebook and passed a one-time review.'),
+    ];
 
     return $form;
   }
@@ -39,7 +445,11 @@ class ApiSettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('fb_instant_articles_api.settings')
+      ->set('development_mode', $form_state->getValue('development_mode'))
+      ->save();
 
+    parent::submitForm($form, $form_state);
   }
 
 }

--- a/modules/fb_instant_articles_api/tests/src/Functional/ApiSettingsFormTest.php
+++ b/modules/fb_instant_articles_api/tests/src/Functional/ApiSettingsFormTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\Tests\fb_instant_articles_api\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests the FBIA API settings form.
+ *
+ * @group fb_instant_articles_api
+ */
+class ApiSettingsFormTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'node',
+    'fb_instant_articles_api',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+    $this->drupalLogin($this->rootUser);
+  }
+
+  /**
+   * Test the various stages of form input for the API settings form.
+   */
+  public function testBuildForm() {
+    $this->drupalGet('/admin/config/services/fb_instant_articles/api_settings');
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Initially we should show the App ID and App Secret fields.
+    $this->assertSession()->fieldExists('app_id');
+    $this->assertSession()->fieldExists('app_secret');
+
+    // Clicking Next right away should produce an error.
+    $this->drupalPostForm(NULL, [], t('Next'));
+    $this->assertSession()->pageTextContains('You must enter the App ID before proceeding');
+
+    // Clicking Next with invalid input should produce an error.
+    $this->drupalPostForm(NULL, ['app_id' => 'invalid'], t('Next'));
+    $this->assertSession()->pageTextContains('The App ID that you entered is invalid');
+
+    // Set valid values for app_id and app_secret.
+    $app_id = '1234';
+    $app_secret = 'secret';
+    $this->drupalPostForm(NULL, ['app_id' => $app_id, 'app_secret' => $app_secret], t('Next'));
+    $this->drupalGet('/admin/config/services/fb_instant_articles/api_settings');
+    $this->assertSession()->pageTextContains('Your Facebook App ID is ' . $app_id);
+
+    // Clicking "Update Facebook app id." should allow us to change the app_id
+    // and secret again.
+    $this->clickLink('Update Facebook app id');
+    $this->assertSession()->fieldExists('app_id');
+    $this->assertSession()->fieldExists('app_secret');
+
+    // Set an access_token and page_id in order to test the summary page.
+    $page_id = '1234';
+    \Drupal::configFactory()->getEditable('fb_instant_articles.base_settings')
+      ->set('page_id', $page_id)
+      ->save();
+    \Drupal::configFactory()->getEditable('fb_instant_articles_api.settings')
+      ->set('access_token', 'token')
+      ->save();
+    $this->drupalGet('/admin/config/services/fb_instant_articles/api_settings');
+    $this->assertSession()->pageTextContains('Your Facebook App ID is ' . $app_id);
+    $this->assertSession()->pageTextContains('Your Facebook Page ID is ' . $page_id);
+  }
+
+}

--- a/tests/src/Functional/ViewModeToggleTest.php
+++ b/tests/src/Functional/ViewModeToggleTest.php
@@ -13,7 +13,7 @@ use Drupal\Tests\BrowserTestBase;
  *
  * @group fb_instant_articles
  */
-class FbiaViewModeToggleTest extends BrowserTestBase {
+class ViewModeToggleTest extends BrowserTestBase {
 
   /**
    * Modules to enable.


### PR DESCRIPTION
Adds the `fb_instant_articles_api` sub-module as well as the config page for storing API credentials and setting up a connection to the Facebook page to post to.

To test:

 - [ ] Enable fb_instant_articles_api module
 - [ ] Visit `/admin/config/services/fb_instant_articles/api_settings` and use the form.
 - [ ] You'll need to create a Facebook App, and have access to at least on Facebook Page to complete the whole process.