### PR TITLE
Issue #2872808: Implement field formatter for each FBIA element

### DIFF
--- a/fb_instant_articles.module
+++ b/fb_instant_articles.module
@@ -60,10 +60,10 @@ function fb_instant_articles_help($route_name, RouteMatchInterface $route_match)
       $page_id = \Drupal::config('fb_instant_articles.base_settings')->get('page_id');
       $output = '';
       $output .= '<h2>' . t('Setup') . '</h2>';
-      $output .= '<p>' . t('Once you\'ve activated this Drupal module, set up your Instant Articles and submit them to Facebook for a one-time review. The review is required before you can begin publishing. Follow these steps to get started:') . '</p>';
+      $output .= '<p>' . t("Once you've activated this Drupal module, set up your Instant Articles and submit them to Facebook for a one-time review. The review is required before you can begin publishing. Follow these steps to get started:") . '</p>';
       $output .= '<ol>';
       $output .= '  <li>' . t('<a href="@sign_up_url" target="_blank">Sign up</a> for Instant Articles, if you haven\'t already, and enabled the same Facebook Page you have selected.', ['@sign_up_url' => 'https://www.facebook.com/instant_articles/signup']) . '</li>';
-      $output .= '  <li>' . t('Claim the URL you will use to publish articles.</b> Right now, we think the URL for this page is: %url. ', ['%url' => $_SERVER['HTTP_HOST']]);
+      $output .= '  <li>' . t('Claim the URL you will use to publish articles.</b> Right now, we think the URL for this page is: %url.', ['%url' => $_SERVER['HTTP_HOST']]);
       if ($page_id != '') {
         $claim_url = 'https://www.facebook.com/' . $page_id . '/settings/?tab=instant_articles#URL';
         $output .= t('<a href="@claim_url" target="_blank">Claim your URL here.</a>', ['@claim_url' => $claim_url]);

--- a/modules/fb_instant_articles_api/fb_instant_articles_api.routing.yml
+++ b/modules/fb_instant_articles_api/fb_instant_articles_api.routing.yml
@@ -1,5 +1,5 @@
 fb_instant_articles_api.settings_form:
-  path: '/admin/config/services/fb_instant_articles/api_settings'
+  path: 'admin/config/services/fb_instant_articles/api_settings'
   defaults:
     _form: '\Drupal\fb_instant_articles_api\Form\ApiSettingsForm'
     _title: 'Facebook Instant Articles API Settings'

--- a/src/Form/EntityViewDisplayEditForm.php
+++ b/src/Form/EntityViewDisplayEditForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\fb_instant_articles\Form;
 
+use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\field_ui\Form\EntityViewDisplayEditForm as CoreEntityViewDisplayEditForm;
 
 /**
@@ -31,6 +32,23 @@ class EntityViewDisplayEditForm extends CoreEntityViewDisplayEditForm {
       $regions = $new_regions;
     }
     return $regions;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getApplicablePluginOptions(FieldDefinitionInterface $field_definition) {
+    $options = parent::getApplicablePluginOptions($field_definition);
+    // Filter out FBIA formatters for view modes other than the Facebook instant
+    // articles view mode.
+    if ($this->getEntity()->getOriginalMode() !== 'fb_instant_articles') {
+      foreach ($options as $key => $label) {
+        if (preg_match('/^fbia_/', $key)) {
+          unset($options[$key]);
+        }
+      }
+    }
+    return $options;
   }
 
 }

--- a/src/Plugin/Field/FieldFormatter/AdFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/AdFormatter.php
@@ -17,7 +17,7 @@ use Drupal\Core\Form\FormStateInterface;
  *   }
  * )
  */
-class AdFormatter extends FbiaFormatterBase {
+class AdFormatter extends FormatterBase {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/Field/FieldFormatter/AdFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/AdFormatter.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of the 'fbia_ad' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "fbia_ad",
+ *   label = @Translation("FBIA Advertisement"),
+ *   field_types = {
+ *     "text",
+ *     "text_long",
+ *     "text_with_summary",
+ *   }
+ * )
+ */
+class AdFormatter extends FbiaFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'source_type' => self::SOURCE_TYPE_URL,
+      'width' => 320,
+      'height' => 50,
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $element['source_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Source type'),
+      '#description' => $this->t('Add your tracker specifying the URL or embed the full unescaped HTML'),
+      '#default_value' => $this->getSetting('source_type'),
+      '#options' => [
+        self::SOURCE_TYPE_URL => $this->t('URL'),
+        self::SOURCE_TYPE_HTML => $this->t('Embedded HTML'),
+      ],
+    ];
+    $element['height'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Height'),
+      '#description' => $this->t('Height of the iframe element.'),
+      '#default_value' => $this->getSetting('height'),
+    ];
+    $element['width'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Width'),
+      '#description' => $this->t('Width of the iframe element.'),
+      '#default_value' => $this->getSetting('width'),
+    ];
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+    if ($source_type = $this->getSetting('source_type')) {
+      $summary[] = $source_type === self::SOURCE_TYPE_URL ? $this->t('URL') : $this->t('Embedded HTML');
+    }
+    if ($width = $this->getSetting('width')) {
+      $summary[] = $this->t('Width: @width', ['@width' => $width]);
+    }
+    if ($height = $this->getSetting('height')) {
+      $summary[] = $this->t('Height: @height', ['@height' => $height]);
+    }
+    return $summary;
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/AnalyticsFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/AnalyticsFormatter.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of the 'fbia_analytics' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "fbia_analytics",
+ *   label = @Translation("FBIA Analytics"),
+ *   field_types = {
+ *     "text",
+ *     "text_long",
+ *     "text_with_summary",
+ *   }
+ * )
+ */
+class AnalyticsFormatter extends FbiaFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'source_type' => self::SOURCE_TYPE_URL,
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $element['source_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Source type'),
+      '#description' => $this->t('Add your tracker specifying the URL or embed the full unescaped HTML'),
+      '#default_value' => $this->getSetting('source_type'),
+      '#options' => [
+        self::SOURCE_TYPE_URL => $this->t('URL'),
+        self::SOURCE_TYPE_HTML => $this->t('Embedded HTML'),
+      ],
+    ];
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+    if ($source_type = $this->getSetting('source_type')) {
+      $summary[] = $source_type === self::SOURCE_TYPE_URL ? $this->t('URL') : $this->t('Embedded HTML');
+    }
+    return $summary;
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/AnalyticsFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/AnalyticsFormatter.php
@@ -16,7 +16,7 @@ use Drupal\Core\Form\FormStateInterface;
  *   }
  * )
  */
-class AnalyticsFormatter extends FbiaFormatterBase {
+class AnalyticsFormatter extends FormatterBase {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/Field/FieldFormatter/AuthorFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/AuthorFormatter.php
@@ -16,4 +16,4 @@ namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
  *   }
  * )
  */
-class AuthorFormatter extends FbiaFormatterBase {}
+class AuthorFormatter extends FormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/AuthorFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/AuthorFormatter.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
+
+/**
+ * Plugin implementation of the 'fbia_author' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "fbia_author",
+ *   label = @Translation("FBIA Author"),
+ *   field_types = {
+ *     "text",
+ *     "text_long",
+ *     "text_with_summary",
+ *     "list_text",
+ *   }
+ * )
+ */
+class AuthorFormatter extends FbiaFormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/BlockquoteFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/BlockquoteFormatter.php
@@ -15,4 +15,4 @@ namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
  *   }
  * )
  */
-class BlockquoteFormatter extends FbiaFormatterBase {}
+class BlockquoteFormatter extends FormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/BlockquoteFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/BlockquoteFormatter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
+
+/**
+ * Plugin implementation of the 'fbia_blockquote' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "fbia_blockquote",
+ *   label = @Translation("FBIA Blockquote"),
+ *   field_types = {
+ *     "text",
+ *     "text_long",
+ *     "text_with_summary",
+ *   }
+ * )
+ */
+class BlockquoteFormatter extends FbiaFormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/CopyrightFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/CopyrightFormatter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
+
+/**
+ * Plugin implementation of the 'fbia_copyright' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "fbia_copyright",
+ *   label = @Translation("FBIA Copyright"),
+ *   field_types = {
+ *     "text",
+ *     "text_long",
+ *     "text_with_summary",
+ *   }
+ * )
+ */
+class CopyrightFormatter extends FbiaFormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/CopyrightFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/CopyrightFormatter.php
@@ -15,4 +15,4 @@ namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
  *   }
  * )
  */
-class CopyrightFormatter extends FbiaFormatterBase {}
+class CopyrightFormatter extends FormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/CreditsFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/CreditsFormatter.php
@@ -15,4 +15,4 @@ namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
  *   }
  * )
  */
-class CreditsFormatter extends FbiaFormatterBase {}
+class CreditsFormatter extends FormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/CreditsFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/CreditsFormatter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
+
+/**
+ * Plugin implementation of the 'fbia_credits' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "fbia_credits",
+ *   label = @Translation("FBIA Credits"),
+ *   field_types = {
+ *     "text",
+ *     "text_long",
+ *     "text_with_summary",
+ *   }
+ * )
+ */
+class CreditsFormatter extends FbiaFormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/FbiaFormatterBase.php
+++ b/src/Plugin/Field/FieldFormatter/FbiaFormatterBase.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+
+/**
+ * Base class for all of our FBIA field formatters.
+ */
+class FbiaFormatterBase extends FormatterBase {
+
+  const SOURCE_TYPE_URL = 'url';
+
+  const SOURCE_TYPE_HTML = 'html';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    // Do nothing. Our field formatters are unique in that they are not meant
+    // to generate HTML on their own, but only signal to the Serialization API
+    // the fate of this field in the FBIA document.
+    return [];
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/FormatterBase.php
+++ b/src/Plugin/Field/FieldFormatter/FormatterBase.php
@@ -3,12 +3,12 @@
 namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Field\FormatterBase as DrupalFormatterBase;
 
 /**
  * Base class for all of our FBIA field formatters.
  */
-class FbiaFormatterBase extends FormatterBase {
+class FormatterBase extends DrupalFormatterBase {
 
   const SOURCE_TYPE_URL = 'url';
 

--- a/src/Plugin/Field/FieldFormatter/ImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/ImageFormatter.php
@@ -15,7 +15,7 @@ use Facebook\InstantArticles\Elements\Image;
  *   }
  * )
  */
-class ImageFormatter extends FbiaFormatterBase {
+class ImageFormatter extends FormatterBase {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/Field/FieldFormatter/ImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/ImageFormatter.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
+use Drupal\Core\Form\FormStateInterface;
+use Facebook\InstantArticles\Elements\Image;
+
+/**
+ * Plugin implementation of the 'fbia_image' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "fbia_image",
+ *   label = @Translation("FBIA Image"),
+ *   field_types = {
+ *     "image"
+ *   }
+ * )
+ */
+class ImageFormatter extends FbiaFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'image_style' => '',
+      'caption' => '',
+      'likes' => FALSE,
+      'comments' => FALSE,
+      'presentation' => '',
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $element['image_style'] = [
+      '#title' => $this->t('Image style'),
+      '#type' => 'select',
+      '#default_value' => $this->getSetting('image_style'),
+      '#empty_option' => t('None (original image)'),
+      '#options' => image_style_options(),
+    ];
+    $element['caption'] = [
+      '#type' => 'checkbox',
+      '#description' => $this->t('The caption uses the alt text of the image field.'),
+      '#title' => $this->t('Enable caption'),
+      '#default_value' => $this->getSetting('caption'),
+    ];
+    $element['likes'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable Facebook likes'),
+      '#default_value' => $this->getSetting('likes'),
+    ];
+    $element['comments'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable Facebook comments'),
+      '#default_value' => $this->getSetting('comments'),
+    ];
+    $element['presentation'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Presentation'),
+      '#default_value' => $this->getSetting('presentation'),
+      '#options' => [
+        Image::ASPECT_FIT => $this->presentationLabel(Image::ASPECT_FIT),
+        Image::ASPECT_FIT_ONLY => $this->presentationLabel(Image::ASPECT_FIT_ONLY),
+        Image::FULLSCREEN => $this->presentationLabel(Image::FULLSCREEN),
+        Image::NON_INTERACTIVE => $this->presentationLabel(Image::NON_INTERACTIVE),
+      ],
+      '#empty_option' => $this->t('None'),
+    ];
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+    $image_styles = image_style_options();
+    if ($image_style = $this->getSetting('image_style')) {
+      $summary[] = $this->t('Image style: @style', ['@style' => $image_styles[$image_style]]);
+    }
+    else {
+      $summary[] = $this->t('Original image');
+    }
+    if ($this->getSetting('caption')) {
+      $summary[] = $this->t('Use alt text as caption');
+    }
+    if ($this->getSetting('likes')) {
+      $summary[] = $this->t('Enable Facebook likes');
+    }
+    if ($this->getSetting('comments')) {
+      $summary[] = $this->t('Enable Facebook comments');
+    }
+    if ($presentation = $this->getSetting('presentation')) {
+      $summary[] = $this->t('Presentation: @presentation', ['@presentation' => $this->presentationLabel($presentation)]);
+    }
+    return $summary;
+  }
+
+  /**
+   * Given a presentation machine name, return the label.
+   *
+   * @param string $presentation
+   *   Presentation type name.
+   *
+   * @return \Drupal\Core\StringTranslation\TranslatableMarkup
+   *   String label.
+   */
+  protected function presentationLabel($presentation) {
+    switch ($presentation) {
+      case Image::ASPECT_FIT:
+        $label = $this->t('Fit');
+        break;
+
+      case Image::ASPECT_FIT_ONLY:
+        $label = $this->t('Fit only');
+        break;
+
+      case Image::FULLSCREEN:
+        $label = $this->t('Fullscreen');
+        break;
+
+      case Image::NON_INTERACTIVE:
+        $label = $this->t('Non-interactive');
+        break;
+
+      default:
+        $label = $this->t('None');
+        break;
+    }
+    return $label;
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/InteractiveFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/InteractiveFormatter.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Form\FormStateInterface;
+use Facebook\InstantArticles\Elements\Interactive;
+
+/**
+ * Plugin implementation of the 'fbia_interactive' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "fbia_interactive",
+ *   label = @Translation("FBIA Interactive"),
+ *   field_types = {
+ *     "text",
+ *     "text_long",
+ *     "text_with_summary",
+ *   }
+ * )
+ */
+class InteractiveFormatter extends FbiaFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'source_type' => self::SOURCE_TYPE_URL,
+      'width' => '',
+      'height' => '',
+      'margin' => Interactive::NO_MARGIN,
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $element['source_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Source type'),
+      '#description' => $this->t('Add your tracker specifying the URL or embed the full unescaped HTML'),
+      '#default_value' => $this->getSetting('source_type'),
+      '#options' => [
+        self::SOURCE_TYPE_URL => $this->t('URL'),
+        self::SOURCE_TYPE_HTML => $this->t('Embedded HTML'),
+      ],
+    ];
+    $element['width'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Width'),
+      '#description' => $this->t('The width of your interactive graphic.'),
+      '#default_value' => $this->getSetting('width'),
+    ];
+    $element['height'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Height'),
+      '#description' => $this->t('The height of your interactive graphic.'),
+      '#default_value' => $this->getSetting('height'),
+    ];
+    $element['margin'] = [
+      '#type' => 'select',
+      '#title' => t('Margin'),
+      '#description' => t('The margin setting of your intereactive graphic.'),
+      '#default_value' => $this->getSetting('margin'),
+      '#options' => [
+        Interactive::NO_MARGIN => $this->t('No margin'),
+        Interactive::COLUMN_WIDTH => t('Column width'),
+      ],
+    ];
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+    if ($source_type = $this->getSetting('source_type')) {
+      $summary[] = $source_type === self::SOURCE_TYPE_URL ? $this->t('URL') : $this->t('Embedded HTML');
+    }
+    if ($width = $this->getSetting('width')) {
+      $summary[] = $this->t('Width: @width', ['@width' => $width]);
+    }
+    if ($height = $this->getSetting('height')) {
+      $summary[] = $this->t('Height: @height', ['@height' => $height]);
+    }
+    $margin = $this->getSetting('margin');
+    $summary[] = $this->t('Margin setting: @margin', ['@margin' => $margin === Interactive::NO_MARGIN ? $this->t('No margin') : $this->t('Column width')]);
+    return $summary;
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/InteractiveFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/InteractiveFormatter.php
@@ -18,7 +18,7 @@ use Facebook\InstantArticles\Elements\Interactive;
  *   }
  * )
  */
-class InteractiveFormatter extends FbiaFormatterBase {
+class InteractiveFormatter extends FormatterBase {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/Field/FieldFormatter/KickerFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/KickerFormatter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
+
+/**
+ * Plugin implementation of the 'fbia_kicker' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "fbia_kicker",
+ *   label = @Translation("FBIA Kicker"),
+ *   field_types = {
+ *     "text",
+ *     "text_long",
+ *     "text_with_summary",
+ *   }
+ * )
+ */
+class KickerFormatter extends FbiaFormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/KickerFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/KickerFormatter.php
@@ -15,4 +15,4 @@ namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
  *   }
  * )
  */
-class KickerFormatter extends FbiaFormatterBase {}
+class KickerFormatter extends FormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/ListFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/ListFormatter.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of the 'fbia_list' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "fbia_list",
+ *   label = @Translation("FBIA List"),
+ *   field_types = {
+ *     "list_string",
+ *     "list_integer",
+ *     "list_float",
+ *   }
+ * )
+ */
+class ListFormatter extends FbiaFormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'is_ordered' => FALSE,
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $element['is_ordered'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Ordered list'),
+      '#description' => $this->t('Should this list be ordered or not?'),
+      '#default_value' => $this->getSetting('is_ordered'),
+    ];
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    return [$this->getSetting('is_ordered') ? $this->t('Ordered') : $this->t('Unordered')];
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/ListFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/ListFormatter.php
@@ -16,7 +16,7 @@ use Drupal\Core\Form\FormStateInterface;
  *   }
  * )
  */
-class ListFormatter extends FbiaFormatterBase {
+class ListFormatter extends FormatterBase {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/Field/FieldFormatter/PullquoteFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/PullquoteFormatter.php
@@ -15,4 +15,4 @@ namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
  *   }
  * )
  */
-class PullquoteFormatter extends FbiaFormatterBase {}
+class PullquoteFormatter extends FormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/PullquoteFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/PullquoteFormatter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
+
+/**
+ * Plugin implementation of the 'fbia_pullquote' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "fbia_pullquote",
+ *   label = @Translation("FBIA Pullquote"),
+ *   field_types = {
+ *     "text",
+ *     "text_long",
+ *     "text_with_summary",
+ *   }
+ * )
+ */
+class PullquoteFormatter extends FbiaFormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/SocialFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SocialFormatter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
+
+/**
+ * Plugin implementation of the 'fbia_social' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "fbia_social",
+ *   label = @Translation("FBIA Social"),
+ *   field_types = {
+ *     "text",
+ *     "text_long",
+ *     "text_with_summary",
+ *   }
+ * )
+ */
+class SocialFormatter extends FbiaFormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/SocialFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SocialFormatter.php
@@ -15,4 +15,4 @@ namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
  *   }
  * )
  */
-class SocialFormatter extends FbiaFormatterBase {}
+class SocialFormatter extends FormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/SubtitleFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SubtitleFormatter.php
@@ -15,4 +15,4 @@ namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
  *   }
  * )
  */
-class SubtitleFormatter extends FbiaFormatterBase {}
+class SubtitleFormatter extends FormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/SubtitleFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SubtitleFormatter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
+
+/**
+ * Plugin implementation of the 'fbia_subtitle' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "fbia_subtitle",
+ *   label = @Translation("FBIA Subtitle"),
+ *   field_types = {
+ *     "text",
+ *     "text_long",
+ *     "text_with_summary",
+ *   }
+ * )
+ */
+class SubtitleFormatter extends FbiaFormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/TransformerFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/TransformerFormatter.php
@@ -15,4 +15,4 @@ namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
  *   }
  * )
  */
-class TransformerFormatter extends FbiaFormatterBase {}
+class TransformerFormatter extends FormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/TransformerFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/TransformerFormatter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
+
+/**
+ * Plugin implementation of the 'fbia_transformer' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "fbia_transformer",
+ *   label = @Translation("FBIA Transformer"),
+ *   field_types = {
+ *     "text",
+ *     "text_long",
+ *     "text_with_summary",
+ *   }
+ * )
+ */
+class TransformerFormatter extends FbiaFormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/VideoFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/VideoFormatter.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
+
+/**
+ * Plugin implementation of the 'fbia_video' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "fbia_video",
+ *   label = @Translation("FBIA Video"),
+ *   field_types = {
+ *     "file",
+ *   }
+ * )
+ */
+class VideoFormatter extends FbiaFormatterBase {}

--- a/src/Plugin/Field/FieldFormatter/VideoFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/VideoFormatter.php
@@ -13,4 +13,4 @@ namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
  *   }
  * )
  */
-class VideoFormatter extends FbiaFormatterBase {}
+class VideoFormatter extends FormatterBase {}


### PR DESCRIPTION
This adds field formatters for all the FBIA elements we had in the Drupal 7 module. The list includes:

* Ads
* Analytics
* Author
* Blockquote
* Copyright
* Credits
* Image
* Interactive
* Kicker
* List
* Pullquote
* Social
* Subtitle
* Transformer
* Video

This PR simply makes the field formatters available for use. It doesn't do anything to start building the Instant Article, that will come in a later issue. In terms of review, please do a static code review as usual and then check the following:

* You can assign "FBIA" prefixed field formatters to fields in the Mange Display UI for the Facebook Instant Articles display mode, eg. `/admin/structure/types/manage/article/display/fb_instant_articles`
* Assign each formatter in the list above and if applicable try their settings to ensure they work.
* The "FBIA" prefixed field formatters do not show up as an option in other display modes, eg. `/admin/structure/types/manage/article/display/teaser`