### PR TITLE
Issue #2871646 hook_entity_save support for import and delete API operations

### DIFF
--- a/fb_instant_articles.module
+++ b/fb_instant_articles.module
@@ -115,7 +115,7 @@ function fb_instant_articles_form_node_type_form_alter(&$form, FormStateInterfac
 /**
  * Entity builder for the node type form with the FBIA toggle.
  *
- * @see fb_instant_articles_display_form_node_type_form_alter()
+ * @see fb_instant_articles_form_node_type_form_alter()
  */
 function fb_instant_articles_form_node_type_form_builder($entity_type, NodeTypeInterface $type, &$form, FormStateInterface $form_state) {
   if ($form_state->getValue('fb_instant_articles_enabled') === 1) {

--- a/fb_instant_articles.services.yml
+++ b/fb_instant_articles.services.yml
@@ -37,7 +37,7 @@ services:
 
   fb_instant_articles.drupal_client:
     class:  Drupal\fb_instant_articles\DrupalClient
-    arguments: ['@config.factory']
+    arguments: ['@config.factory', '@serializer']
     factory: fb_instant_articles.drupal_client_factory:create
 
   fb_instant_articles.drupal_client_factory:

--- a/fb_instant_articles.services.yml
+++ b/fb_instant_articles.services.yml
@@ -40,7 +40,13 @@ services:
     arguments: ['@config.factory']
     calls:
      - [setSerializer, ['@serializer']]
+     - [setLogger, ['@logger.channel.fbia']]
+     - [setIaNormalizer, ['@serializer.fb_instant_articles.fbia.content_entity']]
     factory: fb_instant_articles.drupal_client_factory:create
 
   fb_instant_articles.drupal_client_factory:
     class: Drupal\fb_instant_articles\DrupalClientFactory
+
+  logger.channel.fbia:
+    parent: logger.channel_base
+    arguments: ['fbia']

--- a/fb_instant_articles.services.yml
+++ b/fb_instant_articles.services.yml
@@ -17,7 +17,7 @@ services:
 
   serializer.fb_instant_articles.fbia_rss.encoder:
     class: Drupal\fb_instant_articles\Encoder\InstantArticleRssEncoder
-    arguments: ['@request_stack']
+    arguments: ['@request_stack', '@config.factory']
     tags:
       - { name: encoder, priority: 10, format: 'fbia_rss' }
 

--- a/fb_instant_articles.services.yml
+++ b/fb_instant_articles.services.yml
@@ -37,7 +37,9 @@ services:
 
   fb_instant_articles.drupal_client:
     class:  Drupal\fb_instant_articles\DrupalClient
-    arguments: ['@config.factory', '@serializer']
+    arguments: ['@config.factory']
+    calls:
+     - [setSerializer, ['@serializer']]
     factory: fb_instant_articles.drupal_client_factory:create
 
   fb_instant_articles.drupal_client_factory:

--- a/modules/fb_instant_articles_api/fb_instant_articles_api.info.yml
+++ b/modules/fb_instant_articles_api/fb_instant_articles_api.info.yml
@@ -1,6 +1,6 @@
 name: Facebook Instant Articles API
 type: module
-description: Implements entity hooks that use the Instant Articles API to delver articles to the Instant Article platform.
+description: Implements entity hooks that use the Instant Articles API to deliver articles to the Instant Article platform.
 core: 8.x
 package: Facebook Instant Articles
 dependencies:

--- a/modules/fb_instant_articles_api/fb_instant_articles_api.info.yml
+++ b/modules/fb_instant_articles_api/fb_instant_articles_api.info.yml
@@ -1,6 +1,6 @@
 name: Facebook Instant Articles API
 type: module
-description: API module for Facebook Instant Articles.
+description: Implements entity hooks that use the Instant Articles API to delver articles to the Instant Article platform.
 core: 8.x
 package: Facebook Instant Articles
 dependencies:

--- a/modules/fb_instant_articles_api/fb_instant_articles_api.module
+++ b/modules/fb_instant_articles_api/fb_instant_articles_api.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\fb_instant_articles\Form\EntityViewDisplayEditForm;
+use Facebook\InstantArticles\Client\InstantArticleStatus;
 
 /**
  * Implements hook_entity_insert().
@@ -39,6 +40,7 @@ function fb_instant_articles_api_entity_save(EntityInterface $entity) {
     /** @var \Drupal\fb_instant_articles\DrupalClient $client */
     $client = \Drupal::service('fb_instant_articles.drupal_client');
     $client->importEntity($entity);
+    drupal_set_message(t('%label published to Facebook Instant Articles.', ['%label' => $entity->label()]));
   }
 }
 
@@ -57,6 +59,9 @@ function fb_instant_articles_api_entity_delete(EntityInterface $entity) {
   if (\Drupal::entityTypeManager()->getStorage('entity_view_display')->load($display_id)) {
     /** @var \Drupal\fb_instant_articles\DrupalClient $client */
     $client = \Drupal::service('fb_instant_articles.drupal_client');
-    $client->removeEntity($entity);
+    $status = $client->removeEntity($entity);
+    if ($status->getStatus() === InstantArticleStatus::SUCCESS) {
+      drupal_set_message(t('%label deleted from Facebook Instant Articles.', ['%label' => $entity->label()]));
+    }
   }
 }

--- a/modules/fb_instant_articles_api/fb_instant_articles_api.module
+++ b/modules/fb_instant_articles_api/fb_instant_articles_api.module
@@ -55,11 +55,8 @@ function fb_instant_articles_api_entity_delete(EntityInterface $entity) {
   // instant articles.
   $display_id = $entity->getEntityTypeId() . '.' . $entity->bundle() . '.' . EntityViewDisplayEditForm::FBIA_VIEW_MODE;
   if (\Drupal::entityTypeManager()->getStorage('entity_view_display')->load($display_id)) {
-    /** @var \Drupal\fb_instant_articles\Normalizer\InstantArticleContentEntityNormalizer $fbia_normalizer */
-    $fbia_normalizer = \Drupal::service('serializer.fb_instant_articles.fbia.content_entity');
-    $url = $fbia_normalizer->entityCanonicalUrl($entity);
     /** @var \Drupal\fb_instant_articles\DrupalClient $client */
     $client = \Drupal::service('fb_instant_articles.drupal_client');
-    $client->removeArticle($url);
+    $client->removeEntity($entity);
   }
 }

--- a/modules/fb_instant_articles_api/fb_instant_articles_api.module
+++ b/modules/fb_instant_articles_api/fb_instant_articles_api.module
@@ -2,5 +2,64 @@
 
 /**
  * @file
- * Hook implemetations for Facebook Instant Articles API module.
+ * Hook imlementations.
  */
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\fb_instant_articles\Form\EntityViewDisplayEditForm;
+
+/**
+ * Implements hook_entity_insert().
+ */
+function fb_instant_articles_api_entity_insert(EntityInterface $entity) {
+  fb_instant_articles_api_entity_save($entity);
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function fb_instant_articles_api_entity_update(EntityInterface $entity) {
+  fb_instant_articles_api_entity_save($entity);
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function fb_instant_articles_api_entity_save(EntityInterface $entity) {
+  // We're only interested in content entities.
+  if (!$entity instanceof ContentEntityInterface) {
+    return;
+  }
+
+  // Only attempt import if this entity is of a bundle that is enabled for
+  // instant articles.
+  $display_id = $entity->getEntityTypeId() . '.' . $entity->bundle() . '.' . EntityViewDisplayEditForm::FBIA_VIEW_MODE;
+  if (\Drupal::entityTypeManager()->getStorage('entity_view_display')->load($display_id)) {
+    /** @var \Drupal\fb_instant_articles\DrupalClient $client */
+    $client = \Drupal::service('fb_instant_articles.drupal_client');
+    $client->importEntity($entity);
+  }
+}
+
+/**
+ * Implements hook_entity_delete().
+ */
+function fb_instant_articles_api_entity_delete(EntityInterface $entity) {
+  // We're only interested in content entities.
+  if (!$entity instanceof ContentEntityInterface) {
+    return;
+  }
+
+  // Only attempt delete if this entity is of a bundle that is enabled for
+  // instant articles.
+  $display_id = $entity->getEntityTypeId() . '.' . $entity->bundle() . '.' . EntityViewDisplayEditForm::FBIA_VIEW_MODE;
+  if (\Drupal::entityTypeManager()->getStorage('entity_view_display')->load($display_id)) {
+    /** @var \Drupal\fb_instant_articles\Normalizer\InstantArticleContentEntityNormalizer $fbia_normalizer */
+    $fbia_normalizer = \Drupal::service('serializer.fb_instant_articles.fbia.content_entity');
+    $url = $fbia_normalizer->entityCanonicalUrl($entity);
+    /** @var \Drupal\fb_instant_articles\DrupalClient $client */
+    $client = \Drupal::service('fb_instant_articles.drupal_client');
+    $client->removeArticle($url);
+  }
+}

--- a/modules/fb_instant_articles_api/fb_instant_articles_api.module
+++ b/modules/fb_instant_articles_api/fb_instant_articles_api.module
@@ -9,6 +9,8 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\fb_instant_articles\Form\EntityViewDisplayEditForm;
 use Facebook\InstantArticles\Client\InstantArticleStatus;
+use Drupal\fb_instant_articles\MissingApiCredentialsException;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_entity_insert().
@@ -37,10 +39,15 @@ function fb_instant_articles_api_entity_save(EntityInterface $entity) {
   // instant articles.
   $display_id = $entity->getEntityTypeId() . '.' . $entity->bundle() . '.' . EntityViewDisplayEditForm::FBIA_VIEW_MODE;
   if (\Drupal::entityTypeManager()->getStorage('entity_view_display')->load($display_id)) {
-    /** @var \Drupal\fb_instant_articles\DrupalClient $client */
-    $client = \Drupal::service('fb_instant_articles.drupal_client');
-    $client->importEntity($entity);
-    drupal_set_message(t('%label published to Facebook Instant Articles.', ['%label' => $entity->label()]));
+    try {
+      /** @var \Drupal\fb_instant_articles\DrupalClient $client */
+      $client = \Drupal::service('fb_instant_articles.drupal_client');
+      $client->importEntity($entity);
+      drupal_set_message(t('%label published to Facebook Instant Articles.', ['%label' => $entity->label()]));
+    }
+    catch (MissingApiCredentialsException $e) {
+      drupal_set_message(t('Error while trying to send entity to Facebook. API credentials haven\'t been configured. Visit the <a href="@api_config">Facebook Instant Articles API configuration page</a> to setup API access.', ['@api_config' => Url::fromRoute('fb_instant_articles.api_settings_form')->toString()]), 'error');
+    }
   }
 }
 
@@ -57,11 +64,16 @@ function fb_instant_articles_api_entity_delete(EntityInterface $entity) {
   // instant articles.
   $display_id = $entity->getEntityTypeId() . '.' . $entity->bundle() . '.' . EntityViewDisplayEditForm::FBIA_VIEW_MODE;
   if (\Drupal::entityTypeManager()->getStorage('entity_view_display')->load($display_id)) {
-    /** @var \Drupal\fb_instant_articles\DrupalClient $client */
-    $client = \Drupal::service('fb_instant_articles.drupal_client');
-    $status = $client->removeEntity($entity);
-    if ($status->getStatus() === InstantArticleStatus::SUCCESS) {
-      drupal_set_message(t('%label deleted from Facebook Instant Articles.', ['%label' => $entity->label()]));
+    try {
+      /** @var \Drupal\fb_instant_articles\DrupalClient $client */
+      $client = \Drupal::service('fb_instant_articles.drupal_client');
+      $status = $client->removeEntity($entity);
+      if ($status->getStatus() === InstantArticleStatus::SUCCESS) {
+        drupal_set_message(t('%label deleted from Facebook Instant Articles.', ['%label' => $entity->label()]));
+      }
+    }
+    catch (MissingApiCredentialsException $e) {
+      drupal_set_message(t('Error while attempting to remove entity from Facebook Instant Articles. API credentials haven\'t been configured. Visit the <a href="@api_config">Facebook Instant Articles API configuration page</a> to setup API access.', ['@api_config' => Url::fromRoute('fb_instant_articles.api_settings_form')->toString()]), 'error');
     }
   }
 }

--- a/modules/fb_instant_articles_api/fb_instant_articles_api.module
+++ b/modules/fb_instant_articles_api/fb_instant_articles_api.module
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Hook imlementations.
+ * Hook implementations.
  */
 
 use Drupal\Core\Entity\EntityInterface;
@@ -27,7 +27,14 @@ function fb_instant_articles_api_entity_update(EntityInterface $entity) {
 }
 
 /**
- * Implements hook_entity_update().
+ * Save the given entity to Instant Articles via the API.
+ *
+ * When an entity is inserted or updated, import the content into Instant
+ * Articles via the API.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   Entity to import into Instant Articles. In practice we only send content
+ *   entities.
  */
 function fb_instant_articles_api_entity_save(EntityInterface $entity) {
   // We're only interested in content entities.

--- a/src/DrupalClient.php
+++ b/src/DrupalClient.php
@@ -78,7 +78,7 @@ class DrupalClient extends FbiaClient {
    */
   public function importEntity(ContentEntityInterface $entity) {
     // Ensure that we have the services we need.
-    if (!isset($this->serializer) || !isset($this->entityTypeManager)) {
+    if (!isset($this->serializer)) {
       throw new \LogicException($this->t('Error importing entity to Facebook Instant Articles. Serializer is not defined.'));
     }
 

--- a/src/DrupalClient.php
+++ b/src/DrupalClient.php
@@ -2,13 +2,19 @@
 
 namespace Drupal\fb_instant_articles;
 
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityPublishedInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\fb_instant_articles\Normalizer\InstantArticleContentEntityNormalizer;
 use Facebook\InstantArticles\Client\Client as FbiaClient;
 use Facebook\Exceptions\FacebookResponseException;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
  * Encapsulate Drupal-specific logic for FBIA Client.
  */
 class DrupalClient extends FbiaClient {
+  use StringTranslationTrait;
 
   /**
    * Facebook Graph API Permision Error Code.
@@ -21,13 +27,30 @@ class DrupalClient extends FbiaClient {
   const FB_INSTANT_ARTICLES_ERROR_CODE_PAGE_NOT_APPROVED = 1888205;
 
   /**
+   * Serializer service.
+   *
+   * @var \Symfony\Component\Serializer\Normalizer\NormalizerInterface
+   */
+  protected $serializer;
+
+  /**
+   * Set the serializer.
+   *
+   * @param \Symfony\Component\Serializer\Normalizer\NormalizerInterface $serializer
+   *   Serializer service. Note that we are type hiting to the
+   *   NormalizerInterface, b/c that is the functionality we actually want to
+   *   use from the Serializer.
+   */
+  public function setSerializer(NormalizerInterface $serializer) {
+    $this->serializer = $serializer;
+  }
+
+  /**
    * {@inheritdoc}
    *
-   * Additionally try to catch an attempted import call.
-   *
-   * @todo Revisit this try/catch wrapper if the API gives an API option to see
-   *   if the page has passed review. This may in fact be the best way, but that
-   *   is still in discussion by the Facebook team.
+   * Additionally try to catch an attempted import call that failed from an
+   * authorization exception. In such a case, try again as unpublished if the
+   * situation allows.
    */
   public function importArticle($article, $published = FALSE, $forceRescrape = FALSE, $formatOutput = FALSE) {
     try {
@@ -38,10 +61,39 @@ class DrupalClient extends FbiaClient {
       // that the page has not yet passed review, try posting the article
       // unpublished. Only try again if the article was intended to be
       // published, so we don't try to post unpublished twice.
-      if ($e->getCode() === self::FB_INSTANT_ARTICLES_ERROR_CODE_PERMISSION && $e->getSubErrorCode() === self::FB_INSTANT_ARTICLES_ERROR_CODE_PAGE_NOT_APPROVED && $takeLive) {
+      if ($e->getCode() === self::FB_INSTANT_ARTICLES_ERROR_CODE_PERMISSION && $e->getSubErrorCode() === self::FB_INSTANT_ARTICLES_ERROR_CODE_PAGE_NOT_APPROVED && $published) {
         parent::importArticle($article, FALSE);
       }
     }
+  }
+
+  /**
+   * Import a content entity into Instant Articles.
+   *
+   * Runs the given entity through the serialization process and finally calls
+   * importArticle() to send it to Instant Articles.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   Entity to import into Instant Articles.
+   */
+  public function importEntity(ContentEntityInterface $entity) {
+    // Ensure that we have the services we need.
+    if (!isset($this->serializer) || !isset($this->entityTypeManager)) {
+      throw new \LogicException($this->t('Error importing entity to Facebook Instant Articles. Serializer is not defined.'));
+    }
+
+    /** @var \Facebook\InstantArticles\Elements\InstantArticle $article */
+    $article = $this->serializer->normalize($entity, InstantArticleContentEntityNormalizer::FORMAT);
+    // Default published status to TRUE for entities that don't implement
+    // EntityPublishedInterface. For those that do implement
+    // EntityPublishedInterface, go by the published status of the entity. Note
+    // that the Development Mode setting under API settings will override this,
+    // so ensure that it is turned off in production.
+    $published = TRUE;
+    if ($entity instanceof EntityPublishedInterface) {
+      $published = $entity->isPublished();
+    }
+    $this->importArticle($article, $published);
   }
 
 }

--- a/src/DrupalClientFactory.php
+++ b/src/DrupalClientFactory.php
@@ -3,7 +3,6 @@
 namespace Drupal\fb_instant_articles;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * Factory class to create a \Drupal\fb_instant_articles\DrupalClient.
@@ -18,9 +17,19 @@ class DrupalClientFactory {
    *
    * @return \Drupal\fb_instant_articles\DrupalClient
    *   Instance of DrupalClient.
+   *
+   * @throws \Drupal\fb_instant_articles\MissingApiCredentialsException
    */
   public static function create(ConfigFactoryInterface $config_factory) {
     $config = $config_factory->get('fb_instant_articles.settings');
+
+    $app_id = $config->get('app_id');
+    $app_secret = $config->get('app_secret');
+    $access_token = $config->get('access_token');
+
+    if (empty($app_id) || empty($app_secret) || empty($access_token)) {
+      throw new MissingApiCredentialsException('The Facebook Instant Articles API has not been configured yet.');
+    }
 
     $client = DrupalClient::create(
       $config->get('app_id'),

--- a/src/DrupalClientFactory.php
+++ b/src/DrupalClientFactory.php
@@ -3,6 +3,7 @@
 namespace Drupal\fb_instant_articles;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * Factory class to create a \Drupal\fb_instant_articles\DrupalClient.
@@ -14,20 +15,25 @@ class DrupalClientFactory {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   Config factory service.
+   * @param \Symfony\Component\Serializer\SerializerInterface $serializer
+   *   Serializer service.
    *
    * @return \Drupal\fb_instant_articles\DrupalClient
    *   Instance of DrupalClient.
    */
-  public static function create(ConfigFactoryInterface $config_factory) {
+  public static function create(ConfigFactoryInterface $config_factory, SerializerInterface $serializer) {
     $config = $config_factory->get('fb_instant_articles.settings');
 
-    return DrupalClient::create(
+    $client = DrupalClient::create(
       $config->get('app_id'),
       $config->get('app_secret'),
       $config->get('access_token'),
       $config->get('page_id'),
       $config->get('development_mode') ?? FALSE
     );
+    $client->setSerializer($serializer);
+
+    return $client;
   }
 
 }

--- a/src/DrupalClientFactory.php
+++ b/src/DrupalClientFactory.php
@@ -15,13 +15,11 @@ class DrupalClientFactory {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   Config factory service.
-   * @param \Symfony\Component\Serializer\SerializerInterface $serializer
-   *   Serializer service.
    *
    * @return \Drupal\fb_instant_articles\DrupalClient
    *   Instance of DrupalClient.
    */
-  public static function create(ConfigFactoryInterface $config_factory, SerializerInterface $serializer) {
+  public static function create(ConfigFactoryInterface $config_factory) {
     $config = $config_factory->get('fb_instant_articles.settings');
 
     $client = DrupalClient::create(
@@ -29,9 +27,8 @@ class DrupalClientFactory {
       $config->get('app_secret'),
       $config->get('access_token'),
       $config->get('page_id'),
-      $config->get('development_mode') ?? FALSE
+      $config->get('development_mode') ? TRUE : FALSE
     );
-    $client->setSerializer($serializer);
 
     return $client;
   }

--- a/src/MissingApiCredentialsException.php
+++ b/src/MissingApiCredentialsException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Drupal\fb_instant_articles;
+
+/**
+ * API client is attempted to be used before it's been configured.
+ */
+class MissingApiCredentialsException extends \Exception {
+}

--- a/src/Normalizer/InstantArticleContentEntityNormalizer.php
+++ b/src/Normalizer/InstantArticleContentEntityNormalizer.php
@@ -13,6 +13,7 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\fb_instant_articles\AdTypes;
+use Drupal\fb_instant_articles\Form\EntityViewDisplayEditForm;
 use Drupal\user\EntityOwnerInterface;
 use Facebook\InstantArticles\Elements\Ad;
 use Facebook\InstantArticles\Elements\Analytics;
@@ -129,10 +130,11 @@ class InstantArticleContentEntityNormalizer extends SerializerAwareNormalizer im
    *   Default entity view display object with the mapping for the given entity.
    */
   protected function entityViewDisplay(ContentEntityInterface $entity, array $context) {
+    $display_id = $entity->getEntityTypeId() . '.' . $entity->bundle() . '.' . EntityViewDisplayEditForm::FBIA_VIEW_MODE;
     if (isset($context['entity_view_display'])) {
       return $context['entity_view_display'];
     }
-    elseif ($display = $this->entityTypeManager->getStorage('entity_view_display')->load($entity->getEntityTypeId() . '.' . $entity->bundle() . '.fb_instant_articles')) {
+    elseif ($display = $this->entityTypeManager->getStorage('entity_view_display')->load($display_id)) {
       return $display;
     }
   }
@@ -163,7 +165,7 @@ class InstantArticleContentEntityNormalizer extends SerializerAwareNormalizer im
    * @return string
    *   The canonical URL for the given entity.
    */
-  protected function entityCanonicalUrl(ContentEntityInterface $entity) {
+  public function entityCanonicalUrl(ContentEntityInterface $entity) {
     if ($override = $this->config->get('canonical_url_override')) {
       return $override . $entity->toUrl('canonical')->toString();
     }

--- a/tests/src/Kernel/Plugin/Field/FieldFormatter/FormatterTestBase.php
+++ b/tests/src/Kernel/Plugin/Field/FieldFormatter/FormatterTestBase.php
@@ -23,6 +23,7 @@ class FormatterTestBase extends KernelTestBase {
     'fb_instant_articles',
     'entity_test',
     'system',
+    'serialization',
   ];
 
   /**

--- a/tests/src/Unit/DrupalClientTest.php
+++ b/tests/src/Unit/DrupalClientTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Drupal\Tests\fb_instant_articles\Unit;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\fb_instant_articles\DrupalClient;
+use Drupal\fb_instant_articles\Normalizer\InstantArticleContentEntityNormalizer;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+use Facebook\InstantArticles\Client\InstantArticleStatus;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Test the Drupal FBIA client wrapper.
+ *
+ * @group fb_instant_articles
+ *
+ * @coversDefaultClass \Drupal\fb_instant_articles\DrupalClient
+ */
+class DrupalClientTest extends UnitTestCase {
+
+  protected $logger;
+
+  protected $serializer;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->serializer = $this->getMock(NormalizerInterface::class);
+    $this->logger = $this->getMock(LoggerChannelInterface::class);
+  }
+
+  /**
+   * Test the import entity method.
+   *
+   * @covers ::importEntity
+   */
+  public function testImportEntity() {
+    $client = $this->getMockBuilder(DrupalClient::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['importArticle'])
+      ->getMock();
+    $client->setStringTranslation($this->getStringTranslationStub());
+    $client->setSerializer($this->serializer);
+    $client->setLogger($this->logger);
+
+    $client->expects($this->once())
+      ->method('importArticle')
+      ->with($this->isNull(), $this->isTrue());
+
+    $client->importEntity($this->getMock(ContentEntityInterface::class));
+
+    // Test that importArticle is called with FALSE for an unpublished entity.
+    $client = $this->getMockBuilder(DrupalClient::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['importArticle'])
+      ->getMock();
+    $client->setStringTranslation($this->getStringTranslationStub());
+    $client->setSerializer($this->serializer);
+    $client->setLogger($this->logger);
+
+    $client->expects($this->once())
+      ->method('importArticle')
+      ->with($this->isNull(), $this->isFalse());
+
+    $entity = $this->getMockBuilder(NodeInterface::class)
+      ->getMock();
+    $entity->method('isPublished')
+      ->willReturn(FALSE);
+
+    $client->importEntity($entity);
+  }
+
+  /**
+   * Test the remove entity method.
+   *
+   * @covers ::removeEntity
+   */
+  public function testRemoveEntity() {
+    // Test that removeArticle is called with the canonical URL from the
+    // iaNormalizer object.
+    $client = $this->getMockBuilder(DrupalClient::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['removeArticle'])
+      ->getMock();
+    $ia_status = $this->getMockBuilder(InstantArticleStatus::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $client->method('removeArticle')
+      ->willReturn($ia_status);
+    $client->setStringTranslation($this->getStringTranslationStub());
+    $client->setLogger($this->logger);
+    $ia_normalizer = $this->getMockBuilder(InstantArticleContentEntityNormalizer::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $ia_normalizer->method('entityCanonicalUrl')
+      ->willReturn('http://www.example.com/node/1');
+    $client->setIaNormalizer($ia_normalizer);
+
+    $client->expects($this->once())
+      ->method('removeArticle')
+      ->with('http://www.example.com/node/1');
+
+    $client->removeEntity($this->getMock(ContentEntityInterface::class));
+  }
+
+}

--- a/tests/src/Unit/InstantArticleContentEntityNormalizerTest.php
+++ b/tests/src/Unit/InstantArticleContentEntityNormalizerTest.php
@@ -86,4 +86,88 @@ class InstantArticleContentEntityNormalizerTest extends ContentEntityNormalizerT
     $this->assertEquals($ads[0]->getSource(), 'http://example.com');
   }
 
+  /**
+   * Tests the sortComponents() method.
+   *
+   * @dataProvider sortComponentsProvider
+   * @covers ::sortComponents
+   */
+  public function testSortComponents($components, $expected) {
+    uasort($components, [InstantArticleContentEntityNormalizer::class, 'sortComponents']);
+    // Re-key the array for equality check.
+    $components = array_values($components);
+    $this->assertEquals($expected, $components);
+  }
+
+  /**
+   * Data provider for testSortComponents.
+   *
+   * @return array
+   *   Return an array or arrays of arguments to testSortComponents.
+   */
+  public function sortComponentsProvider() {
+    return [
+      [
+        [
+          ['region' => 'header', 'weight' => 0],
+          ['region' => 'content', 'weight' => 1],
+          ['region' => 'footer', 'weigth' => 2],
+        ],
+        [
+          ['region' => 'header', 'weight' => 0],
+          ['region' => 'content', 'weight' => 1],
+          ['region' => 'footer', 'weigth' => 2],
+        ],
+      ],
+      [
+        [
+          ['region' => 'header', 'weight' => 0],
+          ['region' => 'footer', 'weight' => 2],
+          ['region' => 'content', 'weight' => 1],
+        ],
+        [
+          ['region' => 'header', 'weight' => 0],
+          ['region' => 'content', 'weight' => 1],
+          ['region' => 'footer', 'weight' => 2],
+        ],
+      ],
+      [
+        [
+          ['region' => 'footer', 'weight' => 2],
+          ['region' => 'header', 'weight' => 0],
+          ['region' => 'content', 'weight' => 1],
+        ],
+        [
+          ['region' => 'header', 'weight' => 0],
+          ['region' => 'content', 'weight' => 1],
+          ['region' => 'footer', 'weight' => 2],
+        ],
+      ],
+      [
+        [
+          ['region' => 'header', 'weight' => 100],
+          ['region' => 'content', 'weight' => -100],
+          ['region' => 'footer', 'weight' => 0],
+        ],
+        [
+          ['region' => 'header', 'weight' => 100],
+          ['region' => 'content', 'weight' => -100],
+          ['region' => 'footer', 'weight' => 0],
+        ],
+      ],
+      [
+        [
+          ['region' => 'footer'],
+          ['region' => 'content'],
+          ['region' => 'header'],
+        ],
+        [
+          ['region' => 'header'],
+          ['region' => 'content'],
+          ['region' => 'footer'],
+        ],
+      ],
+    ];
+  }
+
 }


### PR DESCRIPTION
Integrates with the Instant Articles API to import and delete articles using entity hooks.

This also includes some fixes to the RSS approach to ensure the canonical URL override is used correctly.

To test:

 - [ ] Enable `fb_instant_articles_api` module.
 - [ ] Enable a content type for FBIA
 - [ ] Make sure your API settings are configured.
 - [ ] Create/edit a FBIA node, save it, it should be sent to Facebook

For more detailed testing instructions, see this Paper document: https://paper.dropbox.com/doc/Testing-Drupal-FBIA-Integration-FgIQeFRcEur3FdzOtDvV2