### PR TITLE
Issue #2887794 default view mode

### DIFF
--- a/fb_instant_articles.services.yml
+++ b/fb_instant_articles.services.yml
@@ -12,6 +12,7 @@ services:
 
   serializer.fb_instant_articles.fbia.field_item_list:
     class: Drupal\fb_instant_articles\Normalizer\FieldItemListNormalizer
+    arguments: ['@renderer', '@fb_instant_articles.transformer']
     tags:
       - { name: normalizer, priority: 10 }
 

--- a/src/Normalizer/FieldItemListNormalizer.php
+++ b/src/Normalizer/FieldItemListNormalizer.php
@@ -92,7 +92,6 @@ class FieldItemListNormalizer extends SerializerAwareNormalizer implements Norma
         }
       }
     }
-    // @todo take a crack at doing the conversion without a mapping?
   }
 
 }

--- a/src/Normalizer/FieldItemListNormalizer.php
+++ b/src/Normalizer/FieldItemListNormalizer.php
@@ -2,8 +2,12 @@
 
 namespace Drupal\fb_instant_articles\Normalizer;
 
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterInterface;
+use Drupal\Core\Render\RendererInterface;
 use Drupal\fb_instant_articles\Plugin\Field\InstantArticleFormatterInterface;
+use Drupal\fb_instant_articles\Transformer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
 
@@ -13,6 +17,33 @@ use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
 class FieldItemListNormalizer extends SerializerAwareNormalizer implements NormalizerInterface {
 
   const FORMAT = ['fbia', 'fbia_rss'];
+
+  /**
+   * Renderer service.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  protected $renderer;
+
+  /**
+   * FBIA SDK transformer object.
+   *
+   * @var \Drupal\fb_instant_articles\Transformer
+   */
+  protected $transformer;
+
+  /**
+   * FieldItemListNormalizer constructor.
+   *
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   The renderer service.
+   * @param \Drupal\fb_instant_articles\Transformer $transformer
+   *   FBIA SDK transformer object.
+   */
+  public function __construct(RendererInterface $renderer, Transformer $transformer) {
+    $this->renderer = $renderer;
+    $this->transformer = $transformer;
+  }
 
   /**
    * {@inheritdoc}
@@ -39,12 +70,27 @@ class FieldItemListNormalizer extends SerializerAwareNormalizer implements Norma
     if (isset($context['entity_view_display'])) {
       /** @var \Drupal\Core\Entity\Entity\EntityViewDisplay $display */
       $display = $context['entity_view_display'];
-      $renderer = $display->getRenderer($object->getName());
-      if ($renderer instanceof InstantArticleFormatterInterface) {
+      $formatter = $display->getRenderer($object->getName());
+      if ($formatter instanceof InstantArticleFormatterInterface) {
         $component = $display->getComponent($object->getName());
-        $renderer->viewInstantArticle($object, $article, $component['region']);
+        $formatter->viewInstantArticle($object, $article, $component['region']);
       }
-      // @todo should we try applying Transformer to the rendered output of non-fbia fields?
+      elseif ($formatter instanceof FormatterInterface) {
+        $render_array = $formatter->view($object);
+        if ($markup = (string) $this->renderer->renderPlain($render_array)) {
+
+          // Pass the markup through the Transformer.
+          $document = new \DOMDocument();
+          // Before loading into DOMDocument, setup for success by taking care
+          // of encoding issues.  Since we're dealing with HTML snippets, it
+          // will always be missing a <meta charset="utf-8" /> or equivalent.
+          $markup = '<!doctype html><html><head><meta charset="utf-8" /></head><body>' . $markup . '</body></html>';
+          @$document->loadHTML(Html::decodeEntities($markup));
+
+          // Note that we are putting the content of these fields into the body.
+          $this->transformer->transform($article, $document);
+        }
+      }
     }
     // @todo take a crack at doing the conversion without a mapping?
   }

--- a/src/Normalizer/InstantArticleContentEntityNormalizer.php
+++ b/src/Normalizer/InstantArticleContentEntityNormalizer.php
@@ -129,11 +129,21 @@ class InstantArticleContentEntityNormalizer extends SerializerAwareNormalizer im
    *   Default entity view display object with the mapping for the given entity.
    */
   protected function entityViewDisplay(ContentEntityInterface $entity, array $context) {
-    $display_id = $entity->getEntityTypeId() . '.' . $entity->bundle() . '.' . EntityViewDisplayEditForm::FBIA_VIEW_MODE;
+    $fbia_display_id = $entity->getEntityTypeId() . '.' . $entity->bundle() . '.' . EntityViewDisplayEditForm::FBIA_VIEW_MODE;
+    $default_display_id = $entity->getEntityTypeId() . '.' . $entity->bundle() . '.default';
+    $storage = $this->entityTypeManager->getStorage('entity_view_display');
+
+    /** @var \Drupal\Core\Entity\Entity\EntityViewDisplay $display */
+    // If there is a display passed via $context, use that one.
     if (isset($context['entity_view_display'])) {
       return $context['entity_view_display'];
     }
-    elseif ($display = $this->entityTypeManager->getStorage('entity_view_display')->load($display_id)) {
+    // Try loading the fb_instant_articles entity view display.
+    elseif (($display = $storage->load($fbia_display_id)) && $display->status()) {
+      return $display;
+    }
+    // Try loading the default entity view display.
+    elseif ($display = $storage->load($default_display_id)) {
       return $display;
     }
   }

--- a/src/Normalizer/InstantArticleContentEntityNormalizer.php
+++ b/src/Normalizer/InstantArticleContentEntityNormalizer.php
@@ -108,11 +108,6 @@ class InstantArticleContentEntityNormalizer extends SerializerAwareNormalizer im
         $this->serializer->normalize($data->get($name), $format, $context);
       }
     }
-    else {
-      foreach ($data as $name => $field) {
-        $this->serializer->normalize($field, $format, $context);
-      }
-    }
 
     return $article;
   }

--- a/src/Plugin/Field/FieldFormatter/FormatterBase.php
+++ b/src/Plugin/Field/FieldFormatter/FormatterBase.php
@@ -18,6 +18,11 @@ class FormatterBase extends DrupalFormatterBase implements ContainerFactoryPlugi
 
   const SOURCE_TYPE_HTML = 'html';
 
+  /**
+   * Renderer service.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
   protected $renderer;
 
   /**

--- a/src/Plugin/Field/FieldFormatter/TransformerFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/TransformerFormatter.php
@@ -26,6 +26,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class TransformerFormatter extends FormatterBase implements InstantArticleFormatterInterface {
 
+  /**
+   * FBIA SDK transformer object.
+   *
+   * @var \Drupal\fb_instant_articles\Transformer
+   */
   protected $transformer;
 
   /**

--- a/src/TransformerRulesManager.php
+++ b/src/TransformerRulesManager.php
@@ -90,9 +90,21 @@ class TransformerRulesManager {
         'class' => PassThroughRule::class,
         'selector' => 'span',
       ],
+      // The Facebook Transformer doesn't handle nested div's very well, which
+      // ends up being a problem when using non-FBIA prefixed fields, b/c fields
+      // use a lot of divs. This rule matches div's with a child element,
+      // passing them through to continue transforming their children. Note the
+      // more specific rule below which will match any div with a non-empty
+      // text child node, which will match before this, and start a Paragraph.
+      [
+        'class' => PassThroughRule::class,
+        'selector' => '//div[*]',
+      ],
+      // Match any div with a child text node that is non-empty of length
+      // greater than 0.
       [
         'class' => ParagraphRule::class,
-        'selector' => 'div',
+        'selector' => '//div[string-length(normalize-space(text())) > 0]',
       ],
       [
         'class' => ParagraphRule::class,

--- a/tests/src/Kernel/InstantArticleContentEntityNormalizerTest.php
+++ b/tests/src/Kernel/InstantArticleContentEntityNormalizerTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Drupal\Tests\fb_instant_articles\Kernel;
+
+use Drupal\Core\Entity\Entity\EntityViewDisplay;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\Tests\token\Kernel\KernelTestBase;
+use Drupal\user\Entity\User;
+use Facebook\InstantArticles\Elements\Blockquote;
+use Facebook\InstantArticles\Elements\Paragraph;
+
+/**
+ * Test the Drupal Client wrapper.
+ *
+ * @group fb_instant_articles_temp
+ *
+ * @coversDefaultClass \Drupal\fb_instant_articles\Normalizer\InstantArticleRssContentEntityNormalizer
+ */
+class InstantArticleContentEntityNormalizerTest extends KernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'system',
+    'field',
+    'serialization',
+    'node',
+    'user',
+    'fb_instant_articles',
+  ];
+
+  /**
+   * Entity view display object used in the tests.
+   *
+   * @var \Drupal\Core\Entity\Display\EntityViewDisplayInterface
+   */
+  protected $display;
+
+  /**
+   * Instant article serializer.
+   *
+   * @var \Drupal\fb_instant_articles\Normalizer\InstantArticleContentEntityNormalizer
+   */
+  protected $serializer;
+
+  /**
+   * Name of the test user we are using.
+   *
+   * @var string
+   */
+  protected $userName;
+
+  /**
+   * User entity we are testing with.
+   *
+   * @var \Drupal\user\Entity\User
+   */
+  protected $account;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->serializer = $this->container->get('serializer');
+
+    $this->installSchema('system', 'sequences');
+
+    $this->installConfig(['system', 'field']);
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+
+    // Create a user to use for testing.
+    $this->userName = $this->randomMachineName();
+    $account = User::create(['name' => $this->userName, 'status' => 1]);
+    $account->enforceIsNew();
+    $account->save();
+    $this->account = $account;
+
+    // Create the node bundles required for testing.
+    $type = NodeType::create([
+      'type' => 'article',
+      'name' => 'article',
+    ]);
+    $type->save();
+
+    // Create a couple fields attached to entity_test entity type, which comes
+    // from entity_test module.
+    foreach (['field_one', 'field_two'] as $field_name) {
+      $field_storage = FieldStorageConfig::create([
+        'field_name' => $field_name,
+        'entity_type' => 'node',
+        'type' => 'string_long',
+      ]);
+      $field_storage->save();
+
+      $instance = FieldConfig::create([
+        'field_storage' => $field_storage,
+        'bundle' => 'article',
+        'label' => $this->randomMachineName(),
+      ]);
+      $instance->save();
+    }
+
+    // Create a view mode for testing.
+    $this->display = EntityViewDisplay::create([
+      'targetEntityType' => 'node',
+      'bundle' => 'article',
+      'mode' => 'default',
+      'status' => TRUE,
+    ]);
+  }
+
+  /**
+   * Tests the normalize method with real node objects.
+   *
+   * Validating that the end-to-end functionality of the normalizer works.
+   *
+   * @covers ::normalize
+   */
+  public function testNormalize() {
+    // Setup a node with some simple values for testing.
+    $title = $this->randomString();
+    $node = Node::create([
+      'title' => $title,
+      'type' => 'article',
+      'field_one' => [
+        'value' => 'This is a value for the first field.',
+      ],
+      'field_two' => [
+        'value' => 'This is a value for the second field.',
+      ],
+    ]);
+    $node->setOwner($this->account);
+    $node->save();
+
+    // First test a case of using FBIA formatters.
+    $this->display->setComponent('field_one', [
+      'type' => 'fbia_paragraph',
+      'settings' => [],
+    ]);
+    $this->display->setComponent('field_two', [
+      'type' => 'fbia_blockquote',
+      'settings' => [],
+    ]);
+    $this->display->save();
+
+    $article = $this->serializer->normalize($node, 'fbia', ['entity_view_display' => $this->display]);
+    $this->assertEquals($title, $article->getHeader()->getTitle()->getPlainText());
+    $children = $article->getChildren();
+    $this->assertEquals(2, count($children));
+    $this->assertTrue($children[0] instanceof Paragraph);
+    $this->assertTrue($children[1] instanceof Blockquote);
+
+    // Next test with default field formatters.
+    $this->display->setComponent('field_one', [
+      'type' => 'basic_string',
+      'settings' => [],
+      'label' => 'hidden',
+    ]);
+    $this->display->setComponent('field_two', [
+      'type' => 'basic_string',
+      'settings' => [],
+      'label' => 'hidden',
+    ]);
+    $this->display->save();
+
+    $article = $this->serializer->normalize($node, 'fbia', ['entity_view_display' => $this->display]);
+    $this->assertEquals($title, $article->getHeader()->getTitle()->getPlainText());
+    $children = $article->getChildren();
+    $this->assertEquals(2, count($children));
+    $this->assertTrue($children[0] instanceof Paragraph);
+    $this->assertTrue($children[1] instanceof Paragraph);
+    $this->assertTrue('This is a value for the first field.', $children[0]->getPlainText());
+
+    // Re-run the same test with labels.
+    $this->display->setComponent('field_one', [
+      'type' => 'basic_string',
+      'settings' => [],
+    ]);
+    $this->display->setComponent('field_two', [
+      'type' => 'basic_string',
+      'settings' => [],
+    ]);
+    $this->display->save();
+
+    $article = $this->serializer->normalize($node, 'fbia', ['entity_view_display' => $this->display]);
+    $this->assertEquals($title, $article->getHeader()->getTitle()->getPlainText());
+    $children = $article->getChildren();
+    $this->assertEquals(4, count($children));
+  }
+
+}


### PR DESCRIPTION
To test configure the fb_instant_articles view mode with non-FBIA prefixed field formatters. If they show up in the instant article, it's working.