### PR TITLE
Issue #2889771 Enabling IA on a content type at the same time as creating the content type throws and error

### DIFF
--- a/fb_instant_articles.module
+++ b/fb_instant_articles.module
@@ -109,7 +109,13 @@ function fb_instant_articles_form_node_type_form_alter(&$form, FormStateInterfac
     '#default_value' => $node_type->getThirdPartySetting('fb_instant_articles', 'fb_instant_articles_enabled'),
   ];
 
+  // Use an #entity_builder callback to edit a third party setting on the node
+  // type entity before it gets saved to the database.
   $form['#entity_builders'][] = 'fb_instant_articles_form_node_type_form_builder';
+  // Use a #submit callback to save a entity view display entity. This has to be
+  // on #submit so that the node type entity has been saved since the entity
+  // view display entity is dependent on the node type entity.
+  $form['actions']['submit']['#submit'][] = 'fb_instant_articles_form_node_type_form_submit';
 }
 
 /**
@@ -119,30 +125,41 @@ function fb_instant_articles_form_node_type_form_alter(&$form, FormStateInterfac
  */
 function fb_instant_articles_form_node_type_form_builder($entity_type, NodeTypeInterface $type, &$form, FormStateInterface $form_state) {
   if ($form_state->getValue('fb_instant_articles_enabled') === 1) {
+    $type->setThirdPartySetting('fb_instant_articles', 'fb_instant_articles_enabled', 1);
+  }
+  else {
+    $type->unsetThirdPartySetting('fb_instant_articles', 'fb_instant_articles_enabled');
+  }
+}
+
+/**
+ * Submit function for the node type form with the FBIA toggle.
+ */
+function fb_instant_articles_form_node_type_form_submit(&$form, FormStateInterface $form_state) {
+  $entity_type = $form_state->getValue('type');
+  if ($form_state->getValue('fb_instant_articles_enabled') === 1) {
     /** @var \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display */
-    if ($display = \Drupal::entityTypeManager()->getStorage('entity_view_display')->load('node.' . $type->id() . '.fb_instant_articles')) {
+    if ($display = \Drupal::entityTypeManager()->getStorage('entity_view_display')->load('node.' . $entity_type . '.fb_instant_articles')) {
       $display->setStatus(TRUE)
         ->save();
     }
     else {
       $display = new EntityViewDisplay([
-        'id' => 'node.' . $type->id() . '.fb_instant_articles',
+        'id' => 'node.' . $entity_type . '.fb_instant_articles',
         'targetEntityType' => 'node',
-        'bundle' => $type->id(),
+        'bundle' => $entity_type,
         'mode' => 'fb_instant_articles',
         'status' => TRUE,
       ], 'entity_view_display');
       $display->save();
     }
-    $type->setThirdPartySetting('fb_instant_articles', 'fb_instant_articles_enabled', 1);
   }
   else {
     /** @var \Drupal\Core\Entity\Display\EntityDisplayInterface $display */
-    if ($display = \Drupal::entityTypeManager()->getStorage('entity_view_display')->load('node.' . $type->id() . '.fb_instant_articles')) {
+    if ($display = \Drupal::entityTypeManager()->getStorage('entity_view_display')->load('node.' . $entity_type . '.fb_instant_articles')) {
       $display->setStatus(FALSE)
         ->save();
     }
-    $type->unsetThirdPartySetting('fb_instant_articles', 'fb_instant_articles_enabled');
   }
 }
 

--- a/tests/src/Functional/ContentTypeViewModeCreateTest.php
+++ b/tests/src/Functional/ContentTypeViewModeCreateTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Drupal\Tests\fb_instant_articles\Functional;
+
+use Drupal\Core\Url;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Test toggling the FBIA view mode while creating the content type.
+ *
+ * @group fb_instant_articles
+ */
+class ContentTypeViewModeCreateTest extends BrowserTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'fb_instant_articles',
+    'node',
+    'field_ui',
+  ];
+
+  /**
+   * Permissions to grant admin user.
+   *
+   * @var array
+   */
+  protected $permissions = [
+    'access administration pages',
+    'administer content types',
+    'administer display modes',
+    'administer node display',
+    'administer site configuration',
+    'administer fb_instant_articles',
+  ];
+
+  /**
+   * An user with administration permissions.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    // Login as an admin user.
+    $this->adminUser = $this->drupalCreateUser($this->permissions);
+    $this->drupalLogin($this->adminUser);
+  }
+
+  /**
+   * Test creating a new content type with FBIA toggled on.
+   */
+  public function testCreateContentTypeFbia() {
+    // Enable FBIA display on a new content type.
+    $this->drupalGet(Url::fromRoute('node.type_add')->toString());
+    $this->assertSession()->statusCodeEquals(200);
+    $edit = [
+      'name' => 'Test',
+      'type' => 'test',
+      'fb_instant_articles_enabled' => '1',
+    ];
+    $this->submitForm($edit, t('Save and manage fields'));
+    $this->assertSession()->pageTextContains('The content type test has been added.');
+
+    // Check that the FBIA view mode has been turned on.
+    $view_mode_url = Url::fromRoute('entity.entity_view_display.node.default', ['node_type' => 'test'])->toString();
+    $this->drupalGet($view_mode_url);
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->checkboxChecked('edit-display-modes-custom-fb-instant-articles');
+  }
+
+}


### PR DESCRIPTION
Fixes the error that was thrown when a new content type was saved with the FBIA checkbox checked.

To test:

 - Create a new content type and set the "Enable Facebook Instant Articles" checkbox.
 - Save the content type
 - If you didn't get an error, yay! It works.
 - Run the test suite to verify there are no regressions.
 
Note, there is also a functional test included in this to verify the fix as well.