### PR TITLE
Issue #2892840 Removing a field that was configured on the fb_instant_articles view mode throws an error when serializing a node

### DIFF
--- a/fb_instant_articles.module
+++ b/fb_instant_articles.module
@@ -144,13 +144,14 @@ function fb_instant_articles_form_node_type_form_submit(&$form, FormStateInterfa
         ->save();
     }
     else {
-      $display = new EntityViewDisplay([
+      // Create a new view mode if it's not already created.
+      $display = EntityViewDisplay::create([
         'id' => 'node.' . $entity_type . '.fb_instant_articles',
         'targetEntityType' => 'node',
         'bundle' => $entity_type,
         'mode' => 'fb_instant_articles',
         'status' => TRUE,
-      ], 'entity_view_display');
+      ]);
       $display->save();
     }
   }


### PR DESCRIPTION
Check the steps to reproduce from the issue and make sure you don't get any errors.