### PR TITLE
Issue #2892435 FBIA transformer eliminates non-h1,h2 headers

### DIFF
--- a/src/TransformerRulesManager.php
+++ b/src/TransformerRulesManager.php
@@ -215,7 +215,7 @@ class TransformerRulesManager {
       ],
       [
         'class' => H2Rule::class,
-        'selector' => 'h2',
+        'selector' => '//h2|//h3|//h4|//h5|//h6',
       ],
       [
         'class' => InteractiveRule::class,


### PR DESCRIPTION
To test:

* Checkout this branch
* Clear Drupal cache
* Check the RSS feed for a node with h3-h6 elements. They should all be present as h2 elements in the Instant Article markup.