### PR TITLE
Issue #2893626 Image and video does not render correctly when using non-FBIA formatters

### DIFF
--- a/src/Normalizer/FieldItemListNormalizer.php
+++ b/src/Normalizer/FieldItemListNormalizer.php
@@ -76,6 +76,7 @@ class FieldItemListNormalizer extends SerializerAwareNormalizer implements Norma
         $formatter->viewInstantArticle($object, $article, $component['region']);
       }
       elseif ($formatter instanceof FormatterInterface) {
+        $formatter->prepareView([$object->getEntity()->id() => $object]);
         $render_array = $formatter->view($object);
         if ($markup = (string) $this->renderer->renderPlain($render_array)) {
 


### PR DESCRIPTION
To test:

* Checkout branch
* Configure an image/file field on a FBIA enable content type and place it in Header/Body of the FBIA view mode.
* Create a node of this type.
* View the RSS feed and ensure that image is in the feed.