### PR TITLE
Issue #2896337 Nodes are not excluded by the views filter even though Facebook Instant Articles is turned off

### DIFF
--- a/modules/fb_instant_articles_views/src/Plugin/views/filter/ValidFacebookInstantArticles.php
+++ b/modules/fb_instant_articles_views/src/Plugin/views/filter/ValidFacebookInstantArticles.php
@@ -134,7 +134,7 @@ class ValidFacebookInstantArticles extends FilterPluginBase {
       $view_mode_id = 'node.' . $id . '.' . EntityViewDisplayEditForm::FBIA_VIEW_MODE;
       $view_mode = $entity_storage->load($view_mode_id);
 
-      if ($view_mode instanceof EntityViewDisplayInterface) {
+      if ($view_mode instanceof EntityViewDisplayInterface && $view_mode->status()) {
         $node_types[$id] = $id;
       }
     }

--- a/tests/src/Behat/features/rss.feature
+++ b/tests/src/Behat/features/rss.feature
@@ -4,30 +4,41 @@ Feature: Content that has been enabled for Facebook Instant Articles is exposed 
   As an authenticated user
   I need to be able to create and configure one or more content types to be distributed to Facebook Instant Articles via RSS
 
-Scenario: Verify the default FBIA view is available
-  Given I am logged in as a user with the "administrator" role
-  When I am at "/admin/structure/views"
-  Then I should see the text "Facebook Instant Articles RSS"
+  Scenario: Verify the default FBIA view is available
+    Given I am logged in as a user with the "administrator" role
+    When I am at "/admin/structure/views"
+    Then I should see the text "Facebook Instant Articles RSS"
 
-Scenario: Toggle Facebook Instant Article support on a content type
-  Given I am logged in as a user with the "administrator" role
-  And I am at "/admin/structure/types/manage/article"
-  When I click "Facebook Instant Articles"
-  And I check the box "Enable Facebook Instant Articles"
-  And I press "Save content type"
-  And I visit "/admin/structure/types/manage/article/display"
-  Then I should see the text "Facebook Instant Articles"
-  And I visit "/admin/structure/types/manage/article"
-  And I click "Facebook Instant Articles"
-  And I uncheck the box "Enable Facebook Instant Articles"
-  And I press "Save content type"
-  And I visit "/admin/structure/types/manage/article/display"
-  Then I should not see the text "Facebook Instant Articles"
+  Scenario: Toggle Facebook Instant Article support on a content type
+    Given I am logged in as a user with the "administrator" role
+    And "article" content:
+      | title        | body                                                                                            |
+      | Test article | Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Proin eget tortor risus. |
+    And I am at "/admin/structure/types/manage/article"
+    When I click "Facebook Instant Articles"
+    And I check the box "Enable Facebook Instant Articles"
+    And I press "Save content type"
+    And I visit "/admin/structure/types/manage/article/display"
+    Then I should see the text "Facebook Instant Articles"
+    And I visit "/instant-articles.rss"
+    Then the response should contain "Test article"
+    And I visit "/admin/structure/types/manage/article"
+    And I click "Facebook Instant Articles"
+    And I uncheck the box "Enable Facebook Instant Articles"
+    And I press "Save content type"
+    And I visit "/admin/structure/types/manage/article/display"
+    Then I should not see the text "Facebook Instant Articles"
+    And I visit "/instant-articles.rss"
+    Then the response should not contain "Test article"
 
-Scenario: Create content that should show in the RSS feed
-  Given I am logged in as a user with the "administrator" role
-  And "article" content:
-  | title        | body                                                                                            |
-  | Test article | Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Proin eget tortor risus. |
-  And I am at "/instant-articles.rss"
-  Then the response should contain "Test article"
+  Scenario: Create content that should show in the RSS feed
+    Given I am logged in as a user with the "administrator" role
+    And "article" content:
+      | title        | body                                                                                            |
+      | Test article | Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Proin eget tortor risus. |
+    And I am at "/admin/structure/types/manage/article"
+    And I click "Facebook Instant Articles"
+    And I check the box "Enable Facebook Instant Articles"
+    And I press "Save content type"
+    And I am at "/instant-articles.rss"
+    Then the response should contain "Test article"

--- a/tests/src/Kernel/Plugin/Field/FieldFormatter/FormatterTestBase.php
+++ b/tests/src/Kernel/Plugin/Field/FieldFormatter/FormatterTestBase.php
@@ -24,6 +24,7 @@ class FormatterTestBase extends KernelTestBase {
     'entity_test',
     'system',
     'serialization',
+    'user',
   ];
 
   /**
@@ -62,6 +63,7 @@ class FormatterTestBase extends KernelTestBase {
 
     $this->installConfig(['system', 'field']);
     $this->installEntitySchema('entity_test');
+    $this->installEntitySchema('user');
 
     $this->entityType = 'entity_test';
     $this->bundle = $this->entityType;


### PR DESCRIPTION
*To test*

* Checkout branch
* Toggle support for Facebook Instant Articles on on the Content type edit page (eg. `/admin/structure/types/manage/article`), and Save it, such that the FBIA view mode is enabled.
* Create some content of that type and verify it shows in the RSS feed (eg. `/instant-articles.rss`)
* Toggle FBIA off on the same content type.
* Visit `/instant-article.rss`, you should see no content of that type in the views output.