### PR TITLE
Issue #2896986 FBIA video is not showing up in RSS feed

### DIFF
--- a/src/Plugin/Field/FieldFormatter/VideoFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/VideoFormatter.php
@@ -2,14 +2,18 @@
 
 namespace Drupal\fb_instant_articles\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\fb_instant_articles\Plugin\Field\InstantArticleFormatterInterface;
 use Drupal\fb_instant_articles\Regions;
 use Drupal\file\Plugin\Field\FieldFormatter\GenericFileFormatter;
 use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Video;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Plugin implementation of the 'fbia_video' formatter.
@@ -22,7 +26,38 @@ use Facebook\InstantArticles\Elements\Video;
  *   }
  * )
  */
-class VideoFormatter extends GenericFileFormatter implements InstantArticleFormatterInterface {
+class VideoFormatter extends GenericFileFormatter implements InstantArticleFormatterInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * Base settings.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected $config;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, ConfigFactoryInterface $config_factory) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
+    $this->config = $config_factory->get('fb_instant_articles.settings');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['label'],
+      $configuration['view_mode'],
+      $configuration['third_party_settings'],
+      $container->get('config.factory')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -146,6 +181,10 @@ class VideoFormatter extends GenericFileFormatter implements InstantArticleForma
     foreach ($videos as $delta => $video) {
       // Build the Video Element using configured settings.
       $video_uri = file_create_url($video->getFileUri());
+      // Use the canonical URL override if set.
+      if ($canonical_url = $this->config->get('canonical_url_override')) {
+        $video_uri = preg_replace('~^https?://.*?(?=/)~', rtrim($canonical_url, '/'), $video_uri);
+      }
       $video = Video::create();
       $video->withURL($video_uri);
       if ($presentation = $this->getSetting('presentation')) {

--- a/tests/src/Kernel/Plugin/Field/FieldFormatter/VideoFormatterTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldFormatter/VideoFormatterTest.php
@@ -123,14 +123,14 @@ class VideoFormatterTest extends FormatterTestBase {
 
     // Test with a canonical URL set.
     $config = $this->config('fb_instant_articles.settings');
-    $config->set('canonical_url_override', 'http://example.com')
+    $config->set('canonical_url_override', 'http://example.com/override')
       ->save();
     /** @var \Drupal\fb_instant_articles\Plugin\Field\InstantArticleFormatterInterface $formatter */
     $formatter = $this->display->getRenderer($this->fieldName);
     $article = InstantArticle::create();
     $formatter->viewInstantArticle($entity->{$this->fieldName}, $article, Regions::REGION_CONTENT);
     $children = $article->getChildren();
-    $this->assertStringStartsWith('http://example.com', $children[0]->getUrl());
+    $this->assertStringStartsWith('http://example.com/override', $children[0]->getUrl());
   }
 
 }

--- a/tests/src/Kernel/Plugin/Field/FieldFormatter/VideoFormatterTest.php
+++ b/tests/src/Kernel/Plugin/Field/FieldFormatter/VideoFormatterTest.php
@@ -11,6 +11,8 @@ use Facebook\InstantArticles\Elements\Video;
  * Tests for the VideoFormatter.
  *
  * @group fb_instant_articles
+ *
+ * @coversDefaultClass \Drupal\fb_instant_articles\Plugin\Field\FieldFormatter\VideoFormatter
  */
 class VideoFormatterTest extends FormatterTestBase {
 
@@ -47,6 +49,8 @@ class VideoFormatterTest extends FormatterTestBase {
 
   /**
    * Tests the instant article video formatter.
+   *
+   * @covers ::viewInstantArticle
    */
   public function testVideoFormatter() {
     $entity = EntityTest::create([]);
@@ -104,6 +108,29 @@ class VideoFormatterTest extends FormatterTestBase {
     $children = $article->getChildren();
     $this->assertEquals(2, count($children));
     $this->assertTrue($children[0] instanceof Video);
+  }
+
+  /**
+   * Tests the instant article video formatter when a canonical URL is in play.
+   *
+   * @covers ::viewInstantArticle
+   */
+  function testVideoFormatterCanonicalUrl() {
+    $entity = EntityTest::create([]);
+    // Handy method to populate the field with a real value.
+    // @see FileItem::generateSampleValue()
+    $entity->{$this->fieldName}->generateSampleItems(1);
+
+    // Test with a canonical URL set.
+    $config = $this->config('fb_instant_articles.settings');
+    $config->set('canonical_url_override', 'http://example.com')
+      ->save();
+    /** @var \Drupal\fb_instant_articles\Plugin\Field\InstantArticleFormatterInterface $formatter */
+    $formatter = $this->display->getRenderer($this->fieldName);
+    $article = InstantArticle::create();
+    $formatter->viewInstantArticle($entity->{$this->fieldName}, $article, Regions::REGION_CONTENT);
+    $children = $article->getChildren();
+    $this->assertStringStartsWith('http://example.com', $children[0]->getUrl());
   }
 
 }


### PR DESCRIPTION
Fix an issue where Canonical URL was not taken into account with the FBIA video formatter.

**To test**

* Setup a file field on an FBIA enabled content type.
* Configure the FBIA view mode and set that file field to use FBIA video.
* Create content with a value for that file field
* Set a canonical URL in the settings (eg. `/admin/config/services/fb_instant_articles`)
* View the RSS feed (eg. `/instant-articles.rss`) and view source. You should see the URL to the file you added and it should be using the canonical URL you set in settings.