### PR TITLE
Issue #2903112 RTL Support

### DIFF
--- a/fb_instant_articles.services.yml
+++ b/fb_instant_articles.services.yml
@@ -6,7 +6,7 @@ services:
 
   serializer.fb_instant_articles.fbia.content_entity:
     class: Drupal\fb_instant_articles\Normalizer\InstantArticleContentEntityNormalizer
-    arguments: ['@config.factory', '@entity_field.manager', '@entity_type.manager', '@info_parser', '@module_handler']
+    arguments: ['@config.factory', '@entity_field.manager', '@entity_type.manager', '@info_parser', '@module_handler', '@language_manager']
     tags:
       - { name: normalizer, priority: 10 }
 
@@ -24,7 +24,7 @@ services:
 
   serializer.fb_instant_articles.fbia_rss.content_entity:
     class: Drupal\fb_instant_articles\Normalizer\InstantArticleRssContentEntityNormalizer
-    arguments: ['@config.factory', '@entity_field.manager', '@entity_type.manager', '@info_parser', '@module_handler']
+    arguments: ['@config.factory', '@entity_field.manager', '@entity_type.manager', '@info_parser', '@module_handler', '@language_manager']
     tags:
       - { name: normalizer, priority: 10 }
 

--- a/src/Normalizer/InstantArticleContentEntityNormalizer.php
+++ b/src/Normalizer/InstantArticleContentEntityNormalizer.php
@@ -11,6 +11,8 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\fb_instant_articles\AdTypes;
@@ -75,6 +77,13 @@ class InstantArticleContentEntityNormalizer extends SerializerAwareNormalizer im
   protected $moduleHandler;
 
   /**
+   * Current language.
+   *
+   * @var \Drupal\Core\Language\LanguageInterface
+   */
+  protected $currentLanguage;
+
+  /**
    * ContentEntityNormalizer constructor.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config
@@ -87,13 +96,16 @@ class InstantArticleContentEntityNormalizer extends SerializerAwareNormalizer im
    *   Info parser.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   Module handler.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   Language manager interface.
    */
-  public function __construct(ConfigFactoryInterface $config, EntityFieldManagerInterface $entity_field_manager, EntityTypeManagerInterface $entity_type_manager, InfoParserInterface $info_parser, ModuleHandlerInterface $module_handler) {
+  public function __construct(ConfigFactoryInterface $config, EntityFieldManagerInterface $entity_field_manager, EntityTypeManagerInterface $entity_type_manager, InfoParserInterface $info_parser, ModuleHandlerInterface $module_handler, LanguageManagerInterface $language_manager) {
     $this->config = $config->get('fb_instant_articles.settings');
     $this->entityFieldManager = $entity_field_manager;
     $this->entityTypeManager = $entity_type_manager;
     $this->infoParser = $info_parser;
     $this->moduleHandler = $module_handler;
+    $this->currentLanguage = $language_manager->getCurrentLanguage();
   }
 
   /**
@@ -113,6 +125,11 @@ class InstantArticleContentEntityNormalizer extends SerializerAwareNormalizer im
     $article = InstantArticle::create()
       ->addMetaProperty('op:generator:application', 'drupal/fb_instant_articles')
       ->addMetaProperty('op:generator:application:version', $this->getApplicationVersion());
+    // RTL support.
+    if ($this->currentLanguage->getDirection() === LanguageInterface::DIRECTION_RTL) {
+      $article->enableRTL();
+    }
+    // Configured style.
     if ($style = $this->config->get('style')) {
       $article->withStyle($style);
     }

--- a/tests/src/Kernel/InstantArticleContentEntityNormalizerTest.php
+++ b/tests/src/Kernel/InstantArticleContentEntityNormalizerTest.php
@@ -7,7 +7,7 @@ use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
-use Drupal\Tests\token\Kernel\KernelTestBase;
+use Drupal\KernelTests\KernelTestBase;
 use Drupal\user\Entity\User;
 use Facebook\InstantArticles\Elements\Blockquote;
 use Facebook\InstantArticles\Elements\Paragraph;
@@ -15,7 +15,7 @@ use Facebook\InstantArticles\Elements\Paragraph;
 /**
  * Test the Drupal Client wrapper.
  *
- * @group fb_instant_articles_temp
+ * @group fb_instant_articles
  *
  * @coversDefaultClass \Drupal\fb_instant_articles\Normalizer\InstantArticleRssContentEntityNormalizer
  */

--- a/tests/src/Unit/ContentEntityNormalizerTestBase.php
+++ b/tests/src/Unit/ContentEntityNormalizerTestBase.php
@@ -8,6 +8,8 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManager;
 use Drupal\Core\Url;
 use Drupal\fb_instant_articles\Normalizer\InstantArticleContentEntityNormalizer;
 use Drupal\Tests\UnitTestCase;
@@ -44,6 +46,14 @@ class ContentEntityNormalizerTestBase extends UnitTestCase {
       ->willReturn($entity_storage);
     $info_parser = $this->getMock(InfoParserInterface::class);
     $module_handler = $this->getMock(ModuleHandlerInterface::class);
+    $current_language = $this->getMock(LanguageInterface::class);
+    $language_manager = $this->getMockBuilder(LanguageManager::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['getCurrentLanguage'])
+      ->getMock();
+    $language_manager->expects($this->once())
+      ->method('getCurrentLanguage')
+      ->willReturn($current_language);
     $content_entity_normalizer = $this->getMockBuilder($this->getContentEntityNormalizerClassName())
       ->setConstructorArgs([
         $config_factory,
@@ -51,6 +61,7 @@ class ContentEntityNormalizerTestBase extends UnitTestCase {
         $entity_type_manager,
         $info_parser,
         $module_handler,
+        $language_manager
       ])
       ->setMethods(['getApplicableComponents', 'getApplicationVersion'])
       ->getMock();

--- a/tests/src/Unit/ContentEntityNormalizerTestBase.php
+++ b/tests/src/Unit/ContentEntityNormalizerTestBase.php
@@ -31,7 +31,7 @@ class ContentEntityNormalizerTestBase extends UnitTestCase {
    * @return \Drupal\fb_instant_articles\Normalizer\InstantArticleContentEntityNormalizer
    *   Content entity normalizer object to test against.
    */
-  protected function getContentEntityNormalizer(array $settings, array $components) {
+  protected function getContentEntityNormalizer(array $settings = [], array $components = []) {
     $config_factory = $this->getConfigFactoryStub([
       'fb_instant_articles.settings' => $settings,
     ]);

--- a/tests/src/Unit/ContentEntityNormalizerTestBase.php
+++ b/tests/src/Unit/ContentEntityNormalizerTestBase.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Language\Language;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Language\LanguageManager;
 use Drupal\Core\Url;
@@ -21,6 +22,13 @@ use Drupal\user\UserInterface;
 class ContentEntityNormalizerTestBase extends UnitTestCase {
 
   /**
+   * Mock current language.
+   *
+   * @var \Drupal\Core\Language\Language
+   */
+  protected $currentLanguage;
+
+  /**
    * Helper function to create a new ContentEntityNormalizer for testing.
    *
    * @param array $settings
@@ -31,7 +39,7 @@ class ContentEntityNormalizerTestBase extends UnitTestCase {
    * @return \Drupal\fb_instant_articles\Normalizer\InstantArticleContentEntityNormalizer
    *   Content entity normalizer object to test against.
    */
-  protected function getContentEntityNormalizer(array $settings = [], array $components = []) {
+  protected function getContentEntityNormalizer(array $settings = [], array $components = [], $language_direction = LanguageInterface::DIRECTION_LTR) {
     $config_factory = $this->getConfigFactoryStub([
       'fb_instant_articles.settings' => $settings,
     ]);
@@ -46,14 +54,20 @@ class ContentEntityNormalizerTestBase extends UnitTestCase {
       ->willReturn($entity_storage);
     $info_parser = $this->getMock(InfoParserInterface::class);
     $module_handler = $this->getMock(ModuleHandlerInterface::class);
-    $current_language = $this->getMock(LanguageInterface::class);
+    $this->currentLanguage = $this->getMockBuilder(Language::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['getDirection'])
+      ->getMock();
+    $this->currentLanguage->expects($this->any())
+      ->method('getDirection')
+      ->willReturn($language_direction);
     $language_manager = $this->getMockBuilder(LanguageManager::class)
       ->disableOriginalConstructor()
       ->setMethods(['getCurrentLanguage'])
       ->getMock();
     $language_manager->expects($this->once())
       ->method('getCurrentLanguage')
-      ->willReturn($current_language);
+      ->willReturn($this->currentLanguage);
     $content_entity_normalizer = $this->getMockBuilder($this->getContentEntityNormalizerClassName())
       ->setConstructorArgs([
         $config_factory,

--- a/tests/src/Unit/InstantArticleContentEntityNormalizerTest.php
+++ b/tests/src/Unit/InstantArticleContentEntityNormalizerTest.php
@@ -9,6 +9,8 @@ use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManager;
 use Drupal\fb_instant_articles\Normalizer\InstantArticleContentEntityNormalizer;
 use Drupal\node\NodeInterface;
 use Facebook\InstantArticles\Elements\Analytics;
@@ -46,8 +48,16 @@ class InstantArticleContentEntityNormalizerTest extends ContentEntityNormalizerT
       ->getMock();
     $info_parser = $this->getMock(InfoParserInterface::class);
     $module_handler = $this->getMock(ModuleHandlerInterface::class);
+    $current_language = $this->getMock(LanguageInterface::class);
+    $language_manager = $this->getMockBuilder(LanguageManager::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['getCurrentLanguage'])
+      ->getMock();
+    $language_manager->expects($this->once())
+      ->method('getCurrentLanguage')
+      ->willReturn($current_language);
 
-    $normalizer = new InstantArticleContentEntityNormalizer($config_factory, $entity_field_manager, $entity_type_manager, $info_parser, $module_handler);
+    $normalizer = new InstantArticleContentEntityNormalizer($config_factory, $entity_field_manager, $entity_type_manager, $info_parser, $module_handler, $language_manager);
     $this->assertTrue($normalizer->supportsNormalization($content_entity, 'fbia'));
     $this->assertFalse($normalizer->supportsNormalization($content_entity, 'json'));
     $this->assertFalse($normalizer->supportsNormalization($config_entity, 'fbia'));

--- a/tests/src/Unit/InstantArticleContentEntityNormalizerTest.php
+++ b/tests/src/Unit/InstantArticleContentEntityNormalizerTest.php
@@ -2,15 +2,9 @@
 
 namespace Drupal\Tests\fb_instant_articles\Unit;
 
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\Entity\ConfigEntityInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Entity\EntityFieldManagerInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Extension\InfoParserInterface;
-use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Language\LanguageInterface;
-use Drupal\Core\Language\LanguageManager;
 use Drupal\fb_instant_articles\Normalizer\InstantArticleContentEntityNormalizer;
 use Drupal\node\NodeInterface;
 use Facebook\InstantArticles\Elements\Analytics;

--- a/tests/src/Unit/InstantArticleContentEntityNormalizerTest.php
+++ b/tests/src/Unit/InstantArticleContentEntityNormalizerTest.php
@@ -82,6 +82,19 @@ class InstantArticleContentEntityNormalizerTest extends ContentEntityNormalizerT
   }
 
   /**
+   * Tests the normalize method on an RTL site.
+   *
+   * @covers ::normalize
+   */
+  public function testNormalizeRtl() {
+    $normalizer = $this->getContentEntityNormalizer([], [], LanguageInterface::DIRECTION_RTL);
+    $now = time();
+    $entity = $this->getContentEntity(NodeInterface::class, '/node/1', 'Test entity', $now, $now, 'Joe Mayo');
+    $article = $normalizer->normalize($entity, 'fbia');
+    $this->assertTrue($article->isRTLEnabled());
+  }
+
+  /**
    * Tests the sortComponents() method.
    *
    * @dataProvider sortComponentsProvider

--- a/tests/src/Unit/InstantArticleContentEntityNormalizerTest.php
+++ b/tests/src/Unit/InstantArticleContentEntityNormalizerTest.php
@@ -31,33 +31,14 @@ class InstantArticleContentEntityNormalizerTest extends ContentEntityNormalizerT
    * @covers ::supportsNormalization
    */
   public function testSupportsNormalization() {
-    $config_factory = $this->getMockBuilder(ConfigFactoryInterface::class)
-      ->disableOriginalConstructor()
-      ->getMock();
-    $entity_field_manager = $this->getMockBuilder(EntityFieldManagerInterface::class)
-      ->disableOriginalConstructor()
-      ->getMock();
-    $entity_type_manager = $this->getMockBuilder(EntityTypeManagerInterface::class)
-      ->disableOriginalConstructor()
-      ->getMock();
     $content_entity = $this->getMockBuilder(ContentEntityInterface::class)
       ->disableOriginalConstructor()
       ->getMock();
     $config_entity = $this->getMockBuilder(ConfigEntityInterface::class)
       ->disableOriginalConstructor()
       ->getMock();
-    $info_parser = $this->getMock(InfoParserInterface::class);
-    $module_handler = $this->getMock(ModuleHandlerInterface::class);
-    $current_language = $this->getMock(LanguageInterface::class);
-    $language_manager = $this->getMockBuilder(LanguageManager::class)
-      ->disableOriginalConstructor()
-      ->setMethods(['getCurrentLanguage'])
-      ->getMock();
-    $language_manager->expects($this->once())
-      ->method('getCurrentLanguage')
-      ->willReturn($current_language);
 
-    $normalizer = new InstantArticleContentEntityNormalizer($config_factory, $entity_field_manager, $entity_type_manager, $info_parser, $module_handler, $language_manager);
+    $normalizer = $this->getContentEntityNormalizer();
     $this->assertTrue($normalizer->supportsNormalization($content_entity, 'fbia'));
     $this->assertFalse($normalizer->supportsNormalization($content_entity, 'json'));
     $this->assertFalse($normalizer->supportsNormalization($config_entity, 'fbia'));

--- a/tests/src/Unit/InstantArticleRssContentEntityNormalizerTest.php
+++ b/tests/src/Unit/InstantArticleRssContentEntityNormalizerTest.php
@@ -42,33 +42,14 @@ class InstantArticleRssContentEntityNormalizerTest extends ContentEntityNormaliz
    * @covers ::supportsNormalization
    */
   public function testSupportsNormalization() {
-    $config_factory = $this->getMockBuilder(ConfigFactoryInterface::class)
-      ->disableOriginalConstructor()
-      ->getMock();
-    $entity_field_manager = $this->getMockBuilder(EntityFieldManagerInterface::class)
-      ->disableOriginalConstructor()
-      ->getMock();
-    $entity_type_manager = $this->getMockBuilder(EntityTypeManagerInterface::class)
-      ->disableOriginalConstructor()
-      ->getMock();
     $content_entity = $this->getMockBuilder(ContentEntityInterface::class)
       ->disableOriginalConstructor()
       ->getMock();
     $config_entity = $this->getMockBuilder(ConfigEntityInterface::class)
       ->disableOriginalConstructor()
       ->getMock();
-    $info_parser = $this->getMock(InfoParserInterface::class);
-    $module_handler = $this->getMock(ModuleHandlerInterface::class);
-    $current_language = $this->getMock(LanguageInterface::class);
-    $language_manager = $this->getMockBuilder(LanguageManager::class)
-      ->disableOriginalConstructor()
-      ->setMethods(['getCurrentLanguage'])
-      ->getMock();
-    $language_manager->expects($this->once())
-      ->method('getCurrentLanguage')
-      ->willReturn($current_language);
 
-    $normalizer = new InstantArticleRssContentEntityNormalizer($config_factory, $entity_field_manager, $entity_type_manager, $info_parser, $module_handler, $language_manager);
+    $normalizer = $this->getContentEntityNormalizer();
     $this->assertFalse($normalizer->supportsNormalization($content_entity, 'fbia'));
     $this->assertTrue($normalizer->supportsNormalization($content_entity, 'fbia_rss'));
     $this->assertFalse($normalizer->supportsNormalization($content_entity, 'json'));

--- a/tests/src/Unit/InstantArticleRssContentEntityNormalizerTest.php
+++ b/tests/src/Unit/InstantArticleRssContentEntityNormalizerTest.php
@@ -2,17 +2,8 @@
 
 namespace Drupal\Tests\fb_instant_articles\Unit;
 
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\Entity\ConfigEntityInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Entity\EntityFieldManagerInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Extension\InfoParserInterface;
-use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\Core\Language\Language;
-use Drupal\Core\Language\LanguageInterface;
-use Drupal\Core\Language\LanguageManager;
-use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\fb_instant_articles\Normalizer\InstantArticleRssContentEntityNormalizer;
 use Drupal\node\NodeInterface;
 use Facebook\InstantArticles\Elements\InstantArticle;

--- a/tests/src/Unit/InstantArticleRssContentEntityNormalizerTest.php
+++ b/tests/src/Unit/InstantArticleRssContentEntityNormalizerTest.php
@@ -9,6 +9,10 @@ use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Language\Language;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManager;
+use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\fb_instant_articles\Normalizer\InstantArticleRssContentEntityNormalizer;
 use Drupal\node\NodeInterface;
 use Facebook\InstantArticles\Elements\InstantArticle;
@@ -55,8 +59,16 @@ class InstantArticleRssContentEntityNormalizerTest extends ContentEntityNormaliz
       ->getMock();
     $info_parser = $this->getMock(InfoParserInterface::class);
     $module_handler = $this->getMock(ModuleHandlerInterface::class);
+    $current_language = $this->getMock(LanguageInterface::class);
+    $language_manager = $this->getMockBuilder(LanguageManager::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['getCurrentLanguage'])
+      ->getMock();
+    $language_manager->expects($this->once())
+      ->method('getCurrentLanguage')
+      ->willReturn($current_language);
 
-    $normalizer = new InstantArticleRssContentEntityNormalizer($config_factory, $entity_field_manager, $entity_type_manager, $info_parser, $module_handler);
+    $normalizer = new InstantArticleRssContentEntityNormalizer($config_factory, $entity_field_manager, $entity_type_manager, $info_parser, $module_handler, $language_manager);
     $this->assertFalse($normalizer->supportsNormalization($content_entity, 'fbia'));
     $this->assertTrue($normalizer->supportsNormalization($content_entity, 'fbia_rss'));
     $this->assertFalse($normalizer->supportsNormalization($content_entity, 'json'));


### PR DESCRIPTION
This adds support for RTL languages, which is a simple method on the InstantArticle object.

Sites with an RTL language should have the `dir="rtl"` attribute in the HTML element in each article.

To test I enabled the core Language modules, added Hebrew, and then with the Instant Articles Views module turned on, visited: `/he/instant-articles.rss`. Verified the `dir="rtl"` is present.