### PR TITLE
Issue #2780729 Fatal error: Call to undefined function fb_instant_articles_display_get_node_layout_settings()

### DIFF
--- a/modules/fb_instant_articles_api/src/DrupalClient.php
+++ b/modules/fb_instant_articles_api/src/DrupalClient.php
@@ -50,9 +50,9 @@ class DrupalClient extends Client {
    *   if the page has passed review. This may in fact be the best way, but that
    *   is still in discussion by the Facebook team.
    */
-  public function importArticle($article, $takeLive = FALSE) {
+  public function importArticle($article, $takeLive = FALSE, $forceRescrape = false, $formatOutput = false) {
     try {
-      parent::importArticle($article, $takeLive);
+      parent::importArticle($article, $takeLive, $forceRescrape, $formatOutput);
     }
     catch(FacebookResponseException $e) {
       // If this was an authorization exception and the error code indicates

--- a/modules/fb_instant_articles_api_rules/fb_instant_articles_api_rules.module
+++ b/modules/fb_instant_articles_api_rules/fb_instant_articles_api_rules.module
@@ -64,9 +64,15 @@ function facebook_instant_articles_api_remove_action($node, $context = array()) 
 function fb_instant_articles_api_rules_import_article($node) {
   if (isset($node->nid)) {
     // We duplicate this because hook_node_load() is not triggered during node_insert().
-    $layout_settings = fb_instant_articles_display_get_node_layout_settings($node->type);
-    $node->fb_instant_articles_display_wrapper = \Drupal\fb_instant_articles_display\DrupalInstantArticleDisplay::create($node, $layout_settings);
-    node_build_content($node, $view_mode = 'fb_instant_article');
+    $context = array(
+      'entity_type' => 'node',
+      'entity' => $node,
+    );
+    $node->fb_instant_article = \Drupal\fb_instant_articles\ArticleWrapper::create($context)->getArticle();
+
+    // Run node_view and other field formatter hooks.
+    node_build_content($node, 'fb_instant_article');
+
     $client = \Drupal\fb_instant_articles_api\DrupalClient::get();
     $client->importArticle($node->fb_instant_article, $node->status === NODE_PUBLISHED);
   }
@@ -79,8 +85,29 @@ function fb_instant_articles_api_rules_import_article($node) {
  */
 function fb_instant_articles_api_rules_remove_article($node) {
   if (isset($node->nid)) {
-    $url = url(drupal_get_path_alias("node/" . $node->nid), array('absolute' => TRUE));
+    $url = array();
+
+    // We try to depend on $node->path since entity_uri may not be able to
+    // get the alias if the alias is deleted first.
+    if (!empty($node->path['alias'])) {
+      $url['path'] = $node->path['alias'];
+    }
+    else {
+      $url = entity_uri('node', $node);
+    }
+
+    /**
+     * @See \Drupal\fb_instant_articles_display\EntityPropertyMapper\addCanonicalURL()
+     */
+    $canonical_override = variable_get('fb_instant_articles_canonical_url_override', '');
+    if (!empty($canonical_override)) {
+      $url['options']['base_url'] = $canonical_override;
+    }
+
+    $url['options']['absolute'] = TRUE;
+    $canonical_url = url($url['path'], $url['options']);
+
     $client = \Drupal\fb_instant_articles_api\DrupalClient::get();
-    $client->removeArticle($url);
+    $client->removeArticle($canonical_url);
   }
 }

--- a/modules/fb_instant_articles_api_rules/fb_instant_articles_api_rules.module
+++ b/modules/fb_instant_articles_api_rules/fb_instant_articles_api_rules.module
@@ -39,7 +39,7 @@ function fb_instant_articles_api_rules_action_info() {
  */
 function facebook_instant_articles_api_import_action($node, $context = array()) {
   $fb_instant_enabled = fb_instant_articles_display_is_article_type('node', $node->type);
-  if($fb_instant_enabled) {
+  if ($fb_instant_enabled) {
     fb_instant_articles_api_rules_import_article($node);
   }
 }
@@ -51,7 +51,7 @@ function facebook_instant_articles_api_import_action($node, $context = array()) 
  */
 function facebook_instant_articles_api_remove_action($node, $context = array()) {
   $fb_instant_enabled = fb_instant_articles_display_is_article_type('node', $node->type);
-  if($fb_instant_enabled) {
+  if ($fb_instant_enabled) {
     fb_instant_articles_api_rules_remove_article($node);
   }
 }
@@ -96,9 +96,7 @@ function fb_instant_articles_api_rules_remove_article($node) {
       $url = entity_uri('node', $node);
     }
 
-    /**
-     * @See \Drupal\fb_instant_articles_display\EntityPropertyMapper\addCanonicalURL()
-     */
+    // @see \Drupal\fb_instant_articles_display\EntityPropertyMapper\addCanonicalURL()
     $canonical_override = variable_get('fb_instant_articles_canonical_url_override', '');
     if (!empty($canonical_override)) {
       $url['options']['base_url'] = $canonical_override;

--- a/modules/fb_instant_articles_views/views/plugins/views_plugin_row_fiafields.inc
+++ b/modules/fb_instant_articles_views/views/plugins/views_plugin_row_fiafields.inc
@@ -75,7 +75,14 @@ class views_plugin_row_fiafields extends views_plugin_row {
       $nids[] = $row->{$this->field_alias};
     }
     if (!empty($nids)) {
-      $this->nodes = node_load_multiple($nids);
+     // Get a fresh copy of the node to bypass Entity cache module, preventing
+     // getting corrupted Ads/Analytics DOMDocument.
+     if(module_exists('entitycache')) {
+       $this->nodes = node_load_multiple($nids, array(), TRUE);
+     }
+     else {
+       $this->nodes = node_load_multiple($nids);
+     }
     }
   }
 

--- a/modules/fb_instant_articles_views/views/plugins/views_plugin_row_fiafields.inc
+++ b/modules/fb_instant_articles_views/views/plugins/views_plugin_row_fiafields.inc
@@ -77,7 +77,7 @@ class views_plugin_row_fiafields extends views_plugin_row {
     if (!empty($nids)) {
      // Get a fresh copy of the node to bypass Entity cache module, preventing
      // getting corrupted Ads/Analytics DOMDocument.
-     if(module_exists('entitycache')) {
+     if (module_exists('entitycache')) {
        $this->nodes = node_load_multiple($nids, array(), TRUE);
      }
      else {


### PR DESCRIPTION
From #92.

There is code in 7.x-2.x-fb_instant_articles_api_rules.module from 7.x-1.x branch and some function calls are for undefined functions

* fb_instant_articles_display_get_node_layout_settings() does not exist any more.