### PR TITLE
Issue #2909004 by efpapado: Fix PHP71 notices and warnings.

### DIFF
--- a/modules/fb_instant_articles_display/fb_instant_articles_display.module
+++ b/modules/fb_instant_articles_display/fb_instant_articles_display.module
@@ -85,10 +85,12 @@ function fb_instant_articles_display_preprocess(&$variables, $hook) {
     // which case do not process. Also account that #theme may be a hook
     // suggestion itself. For example. #theme = 'comment__node_type' and
     // $hook = 'comment'.
-    $theme_keys = is_string($variables['elements']['#theme']) ? array($variables['elements']['#theme']) : $variables['elements']['#theme'];
-    foreach ($theme_keys as $theme) {
-      if ($theme != $hook && strpos($theme, $hook . '__') !== 0) {
-        return;
+    if (isset($variables['elements']['#theme'])) {
+      $theme_keys = is_string($variables['elements']['#theme']) ? array($variables['elements']['#theme']) : $variables['elements']['#theme'];
+      foreach ($theme_keys as $theme) {
+        if ($theme != $hook && strpos($theme, $hook . '__') !== 0) {
+          return;
+        }
       }
     }
 


### PR DESCRIPTION
Wrap a block of code into an `if(isset(...))` control statement,
to make sure that the array element is actually there.