### PR TITLE
Issue #2914843: Fix PHP error for unallowed array values in class constants

### DIFF
--- a/src/Normalizer/FieldItemListNormalizer.php
+++ b/src/Normalizer/FieldItemListNormalizer.php
@@ -16,8 +16,6 @@ use Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer;
  */
 class FieldItemListNormalizer extends SerializerAwareNormalizer implements NormalizerInterface {
 
-  const FORMAT = ['fbia', 'fbia_rss'];
-
   /**
    * Renderer service.
    *
@@ -49,9 +47,14 @@ class FieldItemListNormalizer extends SerializerAwareNormalizer implements Norma
    * {@inheritdoc}
    */
   public function supportsNormalization($data, $format = NULL) {
+    $supported_formats = [
+      InstantArticleContentEntityNormalizer::FORMAT,
+      InstantArticleRssContentEntityNormalizer::FORMAT,
+    ];
+
     // Only consider this normalizer if we are trying to normalize a field item
-    // list into the 'fbia' format.
-    return in_array($format, static::FORMAT) && $data instanceof FieldItemListInterface;
+    // list into the 'fbia' or 'fbia_rss' format.
+    return in_array($format, $supported_formats) && $data instanceof FieldItemListInterface;
   }
 
   /**


### PR DESCRIPTION
... in FieldItemListNormalizer class

See issue on drupal.org for details: https://www.drupal.org/node/2914843