### PR TITLE
Issue #2915243 Declare the correct cache tag dependency during the RSS views output.

### DIFF
--- a/src/Encoder/InstantArticleRssEncoder.php
+++ b/src/Encoder/InstantArticleRssEncoder.php
@@ -61,7 +61,7 @@ class InstantArticleRssEncoder extends XmlEncoder {
    * {@inheritdoc}
    */
   public function encode($data, $format, array $context = []) {
-    // Force $data into an arry of numeric keys.
+    // Force $data into an array of numeric keys.
     if (!ctype_digit(implode('', array_keys($data)))) {
       $data = [$data];
     }
@@ -73,14 +73,14 @@ class InstantArticleRssEncoder extends XmlEncoder {
       }
     }
     // Wrapping tags.
-    $feed_title = $feed_description = '';
+    $feed_title = $this->t('Facebook Instant Articles RSS Feed');
+    $feed_description = '';
     if (isset($context['views_style_plugin'])) {
       /** @var \Drupal\rest\Plugin\views\style\Serializer $style */
       $style = $context['views_style_plugin'];
       $feed_title = $style->view->getTitle();
       $feed_description = $style->view->storage->get('description');
     }
-    $feed_title = !empty($feed_title) ? $feed_title : $this->t('Facebook Instant Articles RSS Feed');
     $encoded = [
       '@version' => '2.0',
       '@xmlns:content' => 'http://purl.org/rss/1.0/modules/content/',

--- a/src/Normalizer/InstantArticleContentEntityNormalizer.php
+++ b/src/Normalizer/InstantArticleContentEntityNormalizer.php
@@ -144,6 +144,11 @@ class InstantArticleContentEntityNormalizer extends SerializerAwareNormalizer im
     // If we're given an entity_view_display object as context, use that as a
     // mapping to guide the normalization.
     if ($display = $this->entityViewDisplay($data, $context)) {
+      // Declare a dependency on the view mode configuration if we are rendering
+      // in the context of a views REST export.
+      if (isset($context['views_style_plugin'])) {
+        $context['views_style_plugin']->displayHandler->display['cache_metadata']['tags'] = array_merge($context['views_style_plugin']->displayHandler->display['cache_metadata']['tags'], $display->getCacheTags());
+      }
       $context['entity_view_display'] = $display;
       $components = $this->getApplicableComponents($display);
       uasort($components, [$this, 'sortComponents']);

--- a/src/Normalizer/InstantArticleContentEntityNormalizer.php
+++ b/src/Normalizer/InstantArticleContentEntityNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\fb_instant_articles\Normalizer;
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\Entity\EntityViewDisplay;
@@ -147,7 +148,7 @@ class InstantArticleContentEntityNormalizer extends SerializerAwareNormalizer im
       // Declare a dependency on the view mode configuration if we are rendering
       // in the context of a views REST export.
       if (isset($context['views_style_plugin'])) {
-        $context['views_style_plugin']->displayHandler->display['cache_metadata']['tags'] = array_merge($context['views_style_plugin']->displayHandler->display['cache_metadata']['tags'], $display->getCacheTags());
+        $context['views_style_plugin']->displayHandler->display['cache_metadata']['tags'] = Cache::mergeTags($context['views_style_plugin']->displayHandler->display['cache_metadata']['tags'], $display->getCacheTags());
       }
       $context['entity_view_display'] = $display;
       $components = $this->getApplicableComponents($display);


### PR DESCRIPTION
To test:

* Make sure Drupal's Page Cache and Dynamic Page Cache are on. Also helps to have the cache headers enabled.
* Enable the Facebook Instant Articles Views module and configure Article content type. Set the image to use FBIA Image, and enable Likes and Comments.
* Create and article, making sure to set an Image.
* View the feed (`/instant-articles.rss`) and note that likes and comments are enabled for the image of each article by viewing the source.
* Refresh a couple times and, if you have cache headers enabled, note that `X-Drupal-Cache-Tags` should contain a value of `config:core.entity_view_display.node.article.fb_instant_articles`. It should also show as cached with a header of `X-Drupal-Dynamic-Cache: HIT` and/or `X-Drupal-Cache: HIT`.
* Change the FBIA view mode to uncheck Likes and Comments on the FBIA Image formatter.
* Refresh the feed and you should see the updates right away, without having to manually clear the cache.
