### PR TITLE
Issue #2941425 Pin FBIA PHP SDK to 1.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "homepage": "https://www.drupal.org/node/2676800/committers"
   }],
   "require": {
-    "facebook/facebook-instant-articles-sdk-php": "^1.0.0"
+    "facebook/facebook-instant-articles-sdk-php": "1.7.0"
   },
   "require-dev": {
     "drupal/drupal-extension": "dev-master",


### PR DESCRIPTION
1.7.0 was the last version before the logger was refactored and `symfony/css-selector` was narrowly required at `2.8.*`. Since Drupal > 8.4 requires `symfony/css-selector` at `~3.2.8` composer needs to go back to version 1.7.0 anyways. This also resolves an issue with the Logger being refactored in version `1.7.1`, which allows the module to be used in Drupal 8.3.x, which was more liberal about `symfony/css-selector`.